### PR TITLE
Changed class1.control Timed pulse on/off to match specification

### DIFF
--- a/vscp/events/vscp_control.h
+++ b/vscp/events/vscp_control.h
@@ -450,15 +450,14 @@ extern BOOL vscp_control_sendToggleStateEvent(uint8_t userData, uint8_t zone, ui
  * @param[in] userData Optional byte that have a meaning given by the issuer of the event.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
  * @param[in] subZone Sub-zone for which event applies to (0-255). 255 is all sub-zones.
- * @param[in] d Control byte.
- * @param[in] e Set time as a long with MSB in the first byte.
- * @param[in] eSize Size in bytes (1-4)
+ * @param[in] control Control byte.
+ * @param[in] time Set time as a long with MSB in the first byte.
  * @return Status
  * @retval FALSE Failed to send the event
  * @retval TRUE  Event successul sent
  *
  */
-extern BOOL vscp_control_sendTimedPulseOnEvent(uint8_t userData, uint8_t zone, uint8_t subZone, uint8_t d, uint8_t const * const e, uint8_t eSize);
+extern BOOL vscp_control_sendTimedPulseOnEvent(uint8_t userData, uint8_t zone, uint8_t subZone, uint8_t control, uint32_t time);
 
 /**
  * With this event it is possible to generate a timed pulse that is off for a specified time.
@@ -467,14 +466,12 @@ extern BOOL vscp_control_sendTimedPulseOnEvent(uint8_t userData, uint8_t zone, u
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
  * @param[in] subZone Sub-zone for which event applies to (0-255). 255 is all sub-zones.
  * @param[in] control Control byte.
- * @param[in] time Set time as a long with MSB in the first byte.
- * @param[in] timeSize Size in bytes (1-4)
- * @return Status
+ * @param[in] time Set time as a long with MSB in the first byte.* @return Status
  * @retval FALSE Failed to send the event
  * @retval TRUE  Event successul sent
  *
  */
-extern BOOL vscp_control_sendTimedPulseOffEvent(uint8_t userData, uint8_t zone, uint8_t subZone, uint8_t control, uint8_t const * const time, uint8_t timeSize);
+extern BOOL vscp_control_sendTimedPulseOffEvent(uint8_t userData, uint8_t zone, uint8_t subZone, uint8_t control, uint32_t time);
 
 /**
  * Set country language.
@@ -609,6 +606,22 @@ extern BOOL vscp_control_sendLockEvent(uint8_t zone, uint8_t subZone);
  *
  */
 extern BOOL vscp_control_sendUnlockEvent(uint8_t zone, uint8_t subZone);
+
+/**
+ * With this event it is possible to set duty cycle output such as PWM.
+ *
+ * @param[in] repeat Repeat/counter: 0=repeat forever, >0 number of repeats
+ * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
+ * @param[in] subZone Sub-zone for which event applies to (0-255). 255 is all sub-zones.
+ * @param[in] control Control byte.
+ * @param[in] timeOn TimeOn
+ * @param[in] timeOff TimeOff
+ * @return Status
+ * @retval FALSE Failed to send the event
+ * @retval TRUE  Event successul sent
+ *
+ */
+extern BOOL vscp_control_sendPWMEvent(uint8_t repeat, uint8_t zone, uint8_t subZone, uint8_t control, uint16_t timeOn, uint16_t timeOff);
 
 #endif /* __VSCP_CONTROL_H__ */
 


### PR DESCRIPTION
I am not sure why are these events implemented as they are but spec says data bytes 4-7 "Set time as a **long** with MSB in the first byte."... so all bytes are used, no need for variable length.