### PR TITLE
Make node nickname probe configurable

### DIFF
--- a/vscp/templates/vscp_config_overwrite.h
+++ b/vscp/templates/vscp_config_overwrite.h
@@ -130,6 +130,8 @@ extern "C"
 
 #define VSCP_CONFIG_LOOPBACK_STORAGE_NUM        4
 
+#define VSCP_CONFIG_START_NODE_PROBE_NICKNAME   1
+
 */
 
 /*******************************************************************************

--- a/vscp/vscp_config.h
+++ b/vscp/vscp_config.h
@@ -337,6 +337,13 @@ extern "C"
 
 #endif  /* VSCP_CONFIG_BASE_IS_ENABLED( VSCP_CONFIG_ENABLE_LOOPBACK ) */
 
+#ifndef VSCP_CONFIG_START_NODE_PROBE_NICKNAME
+
+/** Number to start probing nickname from. */
+#define VSCP_CONFIG_START_NODE_PROBE_NICKNAME   1
+
+#endif  /* Undefined VSCP_CONFIG_START_NODE_PROBE_NICKNAME */
+
 /*******************************************************************************
     MACROS
 *******************************************************************************/

--- a/vscp/vscp_core.c
+++ b/vscp/vscp_core.c
@@ -802,7 +802,7 @@ static inline void  vscp_core_changeToStateInit(BOOL probeSegmentMaster)
         if (FALSE == probeSegmentMaster)
         {
             vscp_core_initState = INIT_STATE_PROBE;
-            vscp_core_nickname_probe = 1;
+            vscp_core_nickname_probe = VSCP_CONFIG_START_NODE_PROBE_NICKNAME;
         }
         else
         {
@@ -868,7 +868,7 @@ static inline void  vscp_core_stateInit(void)
             vscp_core_initState = INIT_STATE_PROBE;
 
             /* Probe shall start with nickname id 1. */
-            vscp_core_nickname_probe = 1;
+            vscp_core_nickname_probe = VSCP_CONFIG_START_NODE_PROBE_NICKNAME;
         }
         /* Valid message received */
         else if (TRUE == vscp_core_rxMessageValid)


### PR DESCRIPTION
Sometimes I don't want nodes to start probing for free address from 1 but from some other address or random.