### PR TITLE
prog_char is deprecated

### DIFF
--- a/common/avr/can/can.h
+++ b/common/avr/can/can.h
@@ -81,6 +81,7 @@ typedef enum {
     BITRATE_250_KBPS = 5,   // ungetestet
     BITRATE_500_KBPS = 6,   // ungetestet
     BITRATE_1_MBPS = 7,     // ungetestet
+    BITRATE_MAX,            // must always be last
 } can_bitrate_t;
 
 /**

--- a/common/avr/can/src/at90can.c
+++ b/common/avr/can/src/at90can.c
@@ -36,7 +36,7 @@
 
 // ----------------------------------------------------------------------------
 
-prog_char _at90can_cnf[8][3] = {
+PROGMEM const uint8_t _at90can_cnf[BITRATE_MAX][3] = {
     // 10 kbps
     {   0x7E,
         0x6E,
@@ -150,7 +150,7 @@ void _enable_mob_interrupt(uint8_t mob)
 
 bool at90can_init(uint8_t bitrate)
 {
-    if (bitrate >= 8)
+    if (bitrate >= BITRATE_MAX)
         return false;
 
     // switch CAN controller to reset mode


### PR DESCRIPTION
Recent avr-libc versions have deprecated the `prog_char` pseudo type.
Instead, one should use the `PROGMEM` macro.

I also replaced the hardcoded array length with an automatic enum value.
This is still not exactly ideal, but it's slightly better than copy-pasting magic numbers.