### PR TITLE
Prepare v2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     * Type=54 (0x36) - Bootloader CHECK.
   * Measurement related events updated.
   * Fixed VSCP_CLASS_L1_PROTOCOL Type=40 (0x28) Missing parameter node address added.
+  * A lot of unit changes in the measurement realted classes.
 
 ## 2.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.0
+
+  * Supports the new events:
+    * Type=52 (0x34) - Block Data Chunk ACK.
+    * Type=53 (0x35) - Block Data Chunk NACK.
+    * Type=54 (0x36) - Bootloader CHECK.
+  * Measurement related events updated.
+
 ## 2.0.3
 
   * Add missing extern "C" sections to the event headers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0
 
+  * Updated to VSCP v1.15.9.
   * Supports the new VSCP_CLASS_L1_PROTOCOL events:
     * Type=52 (0x34) - Block Data Chunk ACK.
     * Type=53 (0x35) - Block Data Chunk NACK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## 2.1.0
 
-  * Supports the new events:
+  * Supports the new VSCP_CLASS_L1_PROTOCOL events:
     * Type=52 (0x34) - Block Data Chunk ACK.
     * Type=53 (0x35) - Block Data Chunk NACK.
     * Type=54 (0x36) - Bootloader CHECK.
   * Measurement related events updated.
+  * Fixed VSCP_CLASS_L1_PROTOCOL Type=40 (0x28) Missing parameter node address added.
 
 ## 2.0.3
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "VSCP framework"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v2.0.3
+PROJECT_NUMBER         = v2.1.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/common/swTimer.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/common/swTimer.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/common/swTimer.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/common/swTimer.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/common/system.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/common/system.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/source/vscp_frdm_k64f.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/source/vscp_frdm_k64f.c
@@ -30,7 +30,7 @@
 
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_action.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_action.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_action.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_action.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_app_reg.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_app_reg.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_app_reg.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_app_reg.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_config_overwrite.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_dev_data_config_overwrite.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_dev_data_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_platform.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_platform.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_portable.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_portable.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_portable.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_portable.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_ps_access.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_ps_access.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_ps_access.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_ps_access.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_timer.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_timer.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_timer.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_timer.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_tp_adapter.c
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_tp_adapter.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_tp_adapter.h
+++ b/examples/arm/frdm-k64f/vscp_frdm_k64f/vscp_user/vscp_tp_adapter.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/common/swTimer.c
+++ b/examples/avr/at90can/common/swTimer.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/common/swTimer.h
+++ b/examples/avr/at90can/common/swTimer.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/common/system.h
+++ b/examples/avr/at90can/common/system.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/common/time.c
+++ b/examples/avr/at90can/common/time.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/common/time.h
+++ b/examples/avr/at90can/common/time.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/driver/hw.c
+++ b/examples/avr/at90can/driver/hw.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/driver/hw.h
+++ b/examples/avr/at90can/driver/hw.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/driver/serialDrv.c
+++ b/examples/avr/at90can/driver/serialDrv.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/driver/serialDrv.h
+++ b/examples/avr/at90can/driver/serialDrv.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/driver/timerDrv.c
+++ b/examples/avr/at90can/driver/timerDrv.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/driver/timerDrv.h
+++ b/examples/avr/at90can/driver/timerDrv.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/main.c
+++ b/examples/avr/at90can/main.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/makefile
+++ b/examples/avr/at90can/makefile
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 # 
-# Copyright (c) 2014 - 2024 Andreas Merkle
+# Copyright (c) 2014 - 2025 Andreas Merkle
 # http://www.blue-andi.de
 # vscp@blue-andi.de
 # 

--- a/examples/avr/at90can/mdf/exp01.xml
+++ b/examples/avr/at90can/mdf/exp01.xml
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/examples/avr/at90can/vscp_user/vscp_action.c
+++ b/examples/avr/at90can/vscp_user/vscp_action.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_action.h
+++ b/examples/avr/at90can/vscp_user/vscp_action.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_app_reg.c
+++ b/examples/avr/at90can/vscp_user/vscp_app_reg.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_app_reg.h
+++ b/examples/avr/at90can/vscp_user/vscp_app_reg.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_config_overwrite.h
+++ b/examples/avr/at90can/vscp_user/vscp_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_dev_data_config_overwrite.h
+++ b/examples/avr/at90can/vscp_user/vscp_dev_data_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_platform.h
+++ b/examples/avr/at90can/vscp_user/vscp_platform.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_portable.c
+++ b/examples/avr/at90can/vscp_user/vscp_portable.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_portable.h
+++ b/examples/avr/at90can/vscp_user/vscp_portable.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_ps_access.c
+++ b/examples/avr/at90can/vscp_user/vscp_ps_access.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_ps_access.h
+++ b/examples/avr/at90can/vscp_user/vscp_ps_access.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_timer.c
+++ b/examples/avr/at90can/vscp_user/vscp_timer.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_timer.h
+++ b/examples/avr/at90can/vscp_user/vscp_timer.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_tp_adapter.c
+++ b/examples/avr/at90can/vscp_user/vscp_tp_adapter.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/examples/avr/at90can/vscp_user/vscp_tp_adapter.h
+++ b/examples/avr/at90can/vscp_user/vscp_tp_adapter.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "vscp-framework",
-    "version": "2.0.3",
+    "version": "2.1.0",
     "description": "Very Simple Control Procotol (VSCP) Level 1 library with C interface.",
     "keywords": "vscp, vscp-framework, automation, home automation",
     "repository": {

--- a/src/events/vscp_evt_alarm.c
+++ b/src/events/vscp_evt_alarm.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_alarm.h
+++ b/src/events/vscp_evt_alarm.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_aol.c
+++ b/src/events/vscp_evt_aol.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_aol.h
+++ b/src/events/vscp_evt_aol.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_configuration.c
+++ b/src/events/vscp_evt_configuration.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_configuration.h
+++ b/src/events/vscp_evt_configuration.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_control.c
+++ b/src/events/vscp_evt_control.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_control.c
+++ b/src/events/vscp_evt_control.c
@@ -1603,8 +1603,8 @@ extern BOOL vscp_evt_control_sendSetSecurityPin(uint8_t reserved, uint8_t zone, 
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
  * @param[in] subZone Sub-zone for which event applies to (0-255). 255 is all sub-zones.
  * @param[in] securityPassword Security password. This password can be 1-5 bytes and length of event
- * is set accordingly. It should be interpreted as an UTF-8 string with a length set bt event data
- * length - 3 (array[5])
+ * is set accordingly. It should be interpreted as a UTF-8 string of length equal to the event data
+ * length minus 3 bytes (array[5])
  * @param[in] securityPasswordsize Size in byte.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.

--- a/src/events/vscp_evt_control.h
+++ b/src/events/vscp_evt_control.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_control.h
+++ b/src/events/vscp_evt_control.h
@@ -626,8 +626,8 @@ extern BOOL vscp_evt_control_sendSetSecurityPin(uint8_t reserved, uint8_t zone, 
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
  * @param[in] subZone Sub-zone for which event applies to (0-255). 255 is all sub-zones.
  * @param[in] securityPassword Security password. This password can be 1-5 bytes and length of event
- * is set accordingly. It should be interpreted as an UTF-8 string with a length set bt event data
- * length - 3 (array[5])
+ * is set accordingly. It should be interpreted as a UTF-8 string of length equal to the event data
+ * length minus 3 bytes (array[5])
  * @param[in] securityPasswordsize Size in byte.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.

--- a/src/events/vscp_evt_data.c
+++ b/src/events/vscp_evt_data.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_data.h
+++ b/src/events/vscp_evt_data.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_diagnostic.c
+++ b/src/events/vscp_evt_diagnostic.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_diagnostic.h
+++ b/src/events/vscp_evt_diagnostic.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_display.c
+++ b/src/events/vscp_evt_display.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_display.c
+++ b/src/events/vscp_evt_display.c
@@ -394,7 +394,7 @@ extern BOOL vscp_evt_display_sendSetLed(uint8_t index, uint8_t zone, uint8_t sub
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_DISPLAY, VSCP_TYPE_DISPLAY_SHOW_LED, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_DISPLAY, VSCP_TYPE_DISPLAY_SET_LED, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = index;
     size += 1;
@@ -438,7 +438,7 @@ extern BOOL vscp_evt_display_sendSetRgbColor(uint8_t index, uint8_t zone, uint8_
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_DISPLAY, VSCP_TYPE_DISPLAY_SHOW_LED_COLOR, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_DISPLAY, VSCP_TYPE_DISPLAY_SET_COLOR, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = index;
     size += 1;

--- a/src/events/vscp_evt_display.h
+++ b/src/events/vscp_evt_display.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_error.c
+++ b/src/events/vscp_evt_error.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_error.h
+++ b/src/events/vscp_evt_error.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_gnss.c
+++ b/src/events/vscp_evt_gnss.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_gnss.h
+++ b/src/events/vscp_evt_gnss.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_information.c
+++ b/src/events/vscp_evt_information.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_information.h
+++ b/src/events/vscp_evt_information.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_ir.c
+++ b/src/events/vscp_evt_ir.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_ir.h
+++ b/src/events/vscp_evt_ir.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_log.c
+++ b/src/events/vscp_evt_log.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_log.h
+++ b/src/events/vscp_evt_log.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurement.c
+++ b/src/events/vscp_evt_measurement.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurement.c
+++ b/src/events/vscp_evt_measurement.c
@@ -689,7 +689,7 @@ extern BOOL vscp_evt_measurement_sendIlluminance(uint8_t index, uint8_t unit, in
 }
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] index Index for sensor.
  * @param[in] unit The unit of the data.
@@ -698,11 +698,11 @@ extern BOOL vscp_evt_measurement_sendIlluminance(uint8_t index, uint8_t unit, in
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement_sendRadiationDose(uint8_t index, uint8_t unit, int32_t data, int8_t exp)
+extern BOOL vscp_evt_measurement_sendRadiationDoseAbsorbed(uint8_t index, uint8_t unit, int32_t data, int8_t exp)
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_RADIATION_DOSE, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_ABSORBED, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 1;
     txMsg.data[0] = vscp_data_coding_getFormatByte(VSCP_DATA_CODING_REPRESENTATION_NORMALIZED_INTEGER, unit, index);
@@ -1145,7 +1145,7 @@ extern BOOL vscp_evt_measurement_sendLuminance(uint8_t index, uint8_t unit, int3
 }
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] index Index for sensor.
  * @param[in] unit The unit of the data.
@@ -1154,11 +1154,11 @@ extern BOOL vscp_evt_measurement_sendLuminance(uint8_t index, uint8_t unit, int3
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement_sendChemicalConcentration(uint8_t index, uint8_t unit, int32_t data, int8_t exp)
+extern BOOL vscp_evt_measurement_sendChemicalMolarConcentration(uint8_t index, uint8_t unit, int32_t data, int8_t exp)
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION_MOLAR, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 1;
     txMsg.data[0] = vscp_data_coding_getFormatByte(VSCP_DATA_CODING_REPRESENTATION_NORMALIZED_INTEGER, unit, index);
@@ -1168,10 +1168,10 @@ extern BOOL vscp_evt_measurement_sendChemicalConcentration(uint8_t index, uint8_
     return vscp_core_sendEvent(&txMsg);
 }
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] index Index for sensor.
  * @param[in] unit The unit of the data.
@@ -1180,11 +1180,11 @@ extern BOOL vscp_evt_measurement_sendChemicalConcentration(uint8_t index, uint8_
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement_sendDoseEquivalent(uint8_t index, uint8_t unit, int32_t data, int8_t exp)
+extern BOOL vscp_evt_measurement_sendReserved(uint8_t index, uint8_t unit, int32_t data, int8_t exp)
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_DOSE_EQVIVALENT, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_RESERVED47, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 1;
     txMsg.data[0] = vscp_data_coding_getFormatByte(VSCP_DATA_CODING_REPRESENTATION_NORMALIZED_INTEGER, unit, index);

--- a/src/events/vscp_evt_measurement.c
+++ b/src/events/vscp_evt_measurement.c
@@ -1498,7 +1498,7 @@ extern BOOL vscp_evt_measurement_sendRadiationDoseEquivalent(uint8_t index, uint
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_EQ, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT, VSCP_TYPE_MEASUREMENT_DOSE_EQUIVALENT, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 1;
     txMsg.data[0] = vscp_data_coding_getFormatByte(VSCP_DATA_CODING_REPRESENTATION_NORMALIZED_INTEGER, unit, index);

--- a/src/events/vscp_evt_measurement.h
+++ b/src/events/vscp_evt_measurement.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurement.h
+++ b/src/events/vscp_evt_measurement.h
@@ -387,7 +387,7 @@ extern BOOL vscp_evt_measurement_sendLuminousFlux(uint8_t index, uint8_t unit, i
 extern BOOL vscp_evt_measurement_sendIlluminance(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] index Index for sensor.
  * @param[in] unit The unit of the data.
@@ -396,7 +396,7 @@ extern BOOL vscp_evt_measurement_sendIlluminance(uint8_t index, uint8_t unit, in
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement_sendRadiationDose(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
+extern BOOL vscp_evt_measurement_sendRadiationDoseAbsorbed(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
 
 /**
  * Catalytic activity
@@ -615,7 +615,7 @@ extern BOOL vscp_evt_measurement_sendLuminousEnergy(uint8_t index, uint8_t unit,
 extern BOOL vscp_evt_measurement_sendLuminance(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] index Index for sensor.
  * @param[in] unit The unit of the data.
@@ -624,12 +624,12 @@ extern BOOL vscp_evt_measurement_sendLuminance(uint8_t index, uint8_t unit, int3
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement_sendChemicalConcentration(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
+extern BOOL vscp_evt_measurement_sendChemicalMolarConcentration(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] index Index for sensor.
  * @param[in] unit The unit of the data.
@@ -638,7 +638,7 @@ extern BOOL vscp_evt_measurement_sendChemicalConcentration(uint8_t index, uint8_
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement_sendDoseEquivalent(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
+extern BOOL vscp_evt_measurement_sendReserved(uint8_t index, uint8_t unit, int32_t data, int8_t exp);
 
 /* "Reserved" not supported. No frame defined. */
 

--- a/src/events/vscp_evt_measurement32.c
+++ b/src/events/vscp_evt_measurement32.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurement32.c
+++ b/src/events/vscp_evt_measurement32.c
@@ -713,18 +713,18 @@ extern BOOL vscp_evt_measurement32_sendIlluminance(float_t value)
 }
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] value The value is a "float" - IEEE-754, 32 Bits, single precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement32_sendRadiationDose(float_t value)
+extern BOOL vscp_evt_measurement32_sendRadiationDoseAbsorbed(float_t value)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_ABSORBED, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[3];
     txMsg.data[1] = ((uint8_t*)&value)[2];
@@ -1188,18 +1188,18 @@ extern BOOL vscp_evt_measurement32_sendLuminance(float_t value)
 }
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] value The value is a "float" - IEEE-754, 32 Bits, single precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement32_sendChemicalConcentration(float_t value)
+extern BOOL vscp_evt_measurement32_sendChemicalMolarConcentration(float_t value)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION_MOLAR, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[3];
     txMsg.data[1] = ((uint8_t*)&value)[2];
@@ -1212,21 +1212,21 @@ extern BOOL vscp_evt_measurement32_sendChemicalConcentration(float_t value)
     return vscp_core_sendEvent(&txMsg);
 }
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] value The value is a "float" - IEEE-754, 32 Bits, single precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement32_sendDoseEquivalent(float_t value)
+extern BOOL vscp_evt_measurement32_sendReserved(float_t value)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_DOSE_EQVIVALENT, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_RESERVED47, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[3];
     txMsg.data[1] = ((uint8_t*)&value)[2];

--- a/src/events/vscp_evt_measurement32.c
+++ b/src/events/vscp_evt_measurement32.c
@@ -1553,7 +1553,7 @@ extern BOOL vscp_evt_measurement32_sendRadiationDoseEquivalent(float_t value)
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_EQ, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT32, VSCP_TYPE_MEASUREMENT32_DOSE_EQUIVALENT, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[3];
     txMsg.data[1] = ((uint8_t*)&value)[2];

--- a/src/events/vscp_evt_measurement32.h
+++ b/src/events/vscp_evt_measurement32.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurement32.h
+++ b/src/events/vscp_evt_measurement32.h
@@ -312,13 +312,13 @@ extern BOOL vscp_evt_measurement32_sendLuminousFlux(float_t value);
 extern BOOL vscp_evt_measurement32_sendIlluminance(float_t value);
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] value The value is a "float" - IEEE-754, 32 Bits, single precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement32_sendRadiationDose(float_t value);
+extern BOOL vscp_evt_measurement32_sendRadiationDoseAbsorbed(float_t value);
 
 /**
  * Catalytic activity
@@ -483,24 +483,24 @@ extern BOOL vscp_evt_measurement32_sendLuminousEnergy(float_t value);
 extern BOOL vscp_evt_measurement32_sendLuminance(float_t value);
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] value The value is a "float" - IEEE-754, 32 Bits, single precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement32_sendChemicalConcentration(float_t value);
+extern BOOL vscp_evt_measurement32_sendChemicalMolarConcentration(float_t value);
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] value The value is a "float" - IEEE-754, 32 Bits, single precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement32_sendDoseEquivalent(float_t value);
+extern BOOL vscp_evt_measurement32_sendReserved(float_t value);
 
 /* "Reserved" not supported. No frame defined. */
 

--- a/src/events/vscp_evt_measurement64.c
+++ b/src/events/vscp_evt_measurement64.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurement64.c
+++ b/src/events/vscp_evt_measurement64.c
@@ -1785,7 +1785,7 @@ extern BOOL vscp_evt_measurement64_sendRadiationDoseEquivalent(double_t value)
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_EQ, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_DOSE_EQUIVALENT, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[7];
     txMsg.data[1] = ((uint8_t*)&value)[6];

--- a/src/events/vscp_evt_measurement64.c
+++ b/src/events/vscp_evt_measurement64.c
@@ -813,18 +813,18 @@ extern BOOL vscp_evt_measurement64_sendIlluminance(double_t value)
 }
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] value The value is a "double" - IEEE-754, 64 Bits, double precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement64_sendRadiationDose(double_t value)
+extern BOOL vscp_evt_measurement64_sendRadiationDoseAbsorbed(double_t value)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_ABSORBED, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[7];
     txMsg.data[1] = ((uint8_t*)&value)[6];
@@ -1364,18 +1364,18 @@ extern BOOL vscp_evt_measurement64_sendLuminance(double_t value)
 }
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] value The value is a "double" - IEEE-754, 64 Bits, double precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement64_sendChemicalConcentration(double_t value)
+extern BOOL vscp_evt_measurement64_sendChemicalMolarConcentration(double_t value)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION_MOLAR, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[7];
     txMsg.data[1] = ((uint8_t*)&value)[6];
@@ -1392,21 +1392,21 @@ extern BOOL vscp_evt_measurement64_sendChemicalConcentration(double_t value)
     return vscp_core_sendEvent(&txMsg);
 }
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] value The value is a "double" - IEEE-754, 64 Bits, double precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement64_sendDoseEquivalent(double_t value)
+extern BOOL vscp_evt_measurement64_sendReserved(double_t value)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_DOSE_EQVIVALENT, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREMENT64, VSCP_TYPE_MEASUREMENT64_RESERVED47, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = ((uint8_t*)&value)[7];
     txMsg.data[1] = ((uint8_t*)&value)[6];

--- a/src/events/vscp_evt_measurement64.h
+++ b/src/events/vscp_evt_measurement64.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurement64.h
+++ b/src/events/vscp_evt_measurement64.h
@@ -312,13 +312,13 @@ extern BOOL vscp_evt_measurement64_sendLuminousFlux(double_t value);
 extern BOOL vscp_evt_measurement64_sendIlluminance(double_t value);
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] value The value is a "double" - IEEE-754, 64 Bits, double precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement64_sendRadiationDose(double_t value);
+extern BOOL vscp_evt_measurement64_sendRadiationDoseAbsorbed(double_t value);
 
 /**
  * Catalytic activity
@@ -483,24 +483,24 @@ extern BOOL vscp_evt_measurement64_sendLuminousEnergy(double_t value);
 extern BOOL vscp_evt_measurement64_sendLuminance(double_t value);
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] value The value is a "double" - IEEE-754, 64 Bits, double precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement64_sendChemicalConcentration(double_t value);
+extern BOOL vscp_evt_measurement64_sendChemicalMolarConcentration(double_t value);
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] value The value is a "double" - IEEE-754, 64 Bits, double precision.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurement64_sendDoseEquivalent(double_t value);
+extern BOOL vscp_evt_measurement64_sendReserved(double_t value);
 
 /* "Reserved" not supported. No frame defined. */
 

--- a/src/events/vscp_evt_measurezone.c
+++ b/src/events/vscp_evt_measurezone.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurezone.c
+++ b/src/events/vscp_evt_measurezone.c
@@ -764,7 +764,7 @@ extern BOOL vscp_evt_measurezone_sendIlluminance(uint8_t index, uint8_t zone, ui
 }
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -774,11 +774,11 @@ extern BOOL vscp_evt_measurezone_sendIlluminance(uint8_t index, uint8_t zone, ui
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurezone_sendRadiationDose(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp)
+extern BOOL vscp_evt_measurezone_sendRadiationDoseAbsorbed(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp)
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_RADIATION_DOSE, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_ABSORBED, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 3;
     txMsg.data[0] = index;
@@ -1277,7 +1277,7 @@ extern BOOL vscp_evt_measurezone_sendLuminance(uint8_t index, uint8_t zone, uint
 }
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -1287,11 +1287,11 @@ extern BOOL vscp_evt_measurezone_sendLuminance(uint8_t index, uint8_t zone, uint
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurezone_sendChemicalConcentration(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp)
+extern BOOL vscp_evt_measurezone_sendChemicalMolarConcentration(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp)
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION_MOLAR, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 3;
     txMsg.data[0] = index;
@@ -1303,10 +1303,10 @@ extern BOOL vscp_evt_measurezone_sendChemicalConcentration(uint8_t index, uint8_
     return vscp_core_sendEvent(&txMsg);
 }
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -1316,11 +1316,11 @@ extern BOOL vscp_evt_measurezone_sendChemicalConcentration(uint8_t index, uint8_
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurezone_sendDoseEquivalent(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp)
+extern BOOL vscp_evt_measurezone_sendReserved(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp)
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_DOSE_EQVIVALENT, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_RESERVED47, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 3;
     txMsg.data[0] = index;

--- a/src/events/vscp_evt_measurezone.c
+++ b/src/events/vscp_evt_measurezone.c
@@ -1673,7 +1673,7 @@ extern BOOL vscp_evt_measurezone_sendRadiationDoseEquivalent(uint8_t index, uint
 {
     vscp_TxMessage  txMsg;
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_EQ, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_MEASUREZONE, VSCP_TYPE_MEASUREZONE_DOSE_EQUIVALENT, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.dataSize = 3;
     txMsg.data[0] = index;

--- a/src/events/vscp_evt_measurezone.h
+++ b/src/events/vscp_evt_measurezone.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_measurezone.h
+++ b/src/events/vscp_evt_measurezone.h
@@ -413,7 +413,7 @@ extern BOOL vscp_evt_measurezone_sendLuminousFlux(uint8_t index, uint8_t zone, u
 extern BOOL vscp_evt_measurezone_sendIlluminance(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
 
 /**
- * Radiation dose
+ * Radiation dose (absorbed)
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -423,7 +423,7 @@ extern BOOL vscp_evt_measurezone_sendIlluminance(uint8_t index, uint8_t zone, ui
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurezone_sendRadiationDose(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
+extern BOOL vscp_evt_measurezone_sendRadiationDoseAbsorbed(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
 
 /**
  * Catalytic activity
@@ -660,7 +660,7 @@ extern BOOL vscp_evt_measurezone_sendLuminousEnergy(uint8_t index, uint8_t zone,
 extern BOOL vscp_evt_measurezone_sendLuminance(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -670,12 +670,12 @@ extern BOOL vscp_evt_measurezone_sendLuminance(uint8_t index, uint8_t zone, uint
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurezone_sendChemicalConcentration(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
+extern BOOL vscp_evt_measurezone_sendChemicalMolarConcentration(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -685,7 +685,7 @@ extern BOOL vscp_evt_measurezone_sendChemicalConcentration(uint8_t index, uint8_
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_measurezone_sendDoseEquivalent(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
+extern BOOL vscp_evt_measurezone_sendReserved(uint8_t index, uint8_t zone, uint8_t subZone, int32_t data, int8_t exp);
 
 /* "Reserved" not supported. No frame defined. */
 

--- a/src/events/vscp_evt_multimedia.c
+++ b/src/events/vscp_evt_multimedia.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_multimedia.h
+++ b/src/events/vscp_evt_multimedia.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_phone.c
+++ b/src/events/vscp_evt_phone.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_phone.h
+++ b/src/events/vscp_evt_phone.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_protocol.c
+++ b/src/events/vscp_evt_protocol.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_protocol.c
+++ b/src/events/vscp_evt_protocol.c
@@ -1213,90 +1213,28 @@ extern BOOL vscp_evt_protocol_sendGetEventInterest(void)
  * Get event interest response.
  * 
  * @param[in] index Index.
- * @param[in] classBit9 Class bit 9.
- * @param[in] class1 Class 1.
- * @param[in] type1 Type 1. (array[4])
- * @param[in] type1size Size in byte.
- * @param[in] class2 Class 2.
- * @param[in] type2 Type 2. (array[4])
- * @param[in] type2size Size in byte.
- * @param[in] class3 Class 3.
- * @param[in] type3 Type 3. (array[4])
- * @param[in] type3size Size in byte.
+ * @param[in] class Class.
+ * @param[in] type Type.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendGetEventInterestResponse(uint8_t index, uint16_t classBit9, uint8_t class1, uint8_t const * const type1, uint8_t type1Size, uint8_t class2, uint8_t const * const type2, uint8_t type2Size, uint8_t class3, uint8_t const * const type3, uint8_t type3Size)
+extern BOOL vscp_evt_protocol_sendGetEventInterestResponse(uint8_t index, uint16_t class, uint16_t type)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
-    uint8_t         byteIndex   = 0;
-
-    if ((NULL == type1) || (0 == type1Size))
-    {
-        return FALSE;
-    }
-
-    if ((NULL == type2) || (0 == type2Size))
-    {
-        return FALSE;
-    }
-
-    if ((NULL == type3) || (0 == type3Size))
-    {
-        return FALSE;
-    }
 
     vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_PROTOCOL, VSCP_TYPE_PROTOCOL_GET_EVENT_INTEREST_RESPONSE, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = index;
     size += 1;
 
-    txMsg.data[1] = (uint8_t)((classBit9 >> 8) & 0xff);
-    txMsg.data[2] = (uint8_t)((classBit9 >> 0) & 0xff);
+    txMsg.data[1] = (uint8_t)((class >> 8) & 0xff);
+    txMsg.data[2] = (uint8_t)((class >> 0) & 0xff);
     size += 2;
 
-    txMsg.data[2] = class1;
-    size += 1;
-
-    for(byteIndex = 0; byteIndex < type1Size; ++byteIndex)
-    {
-        txMsg.data[3 + byteIndex] = type1[byteIndex];
-        size += 1;
-
-        if (VSCP_L1_DATA_SIZE <= size)
-        {
-            break;
-        }
-    }
-
-    txMsg.data[4] = class2;
-    size += 1;
-
-    for(byteIndex = 0; byteIndex < type2Size; ++byteIndex)
-    {
-        txMsg.data[5 + byteIndex] = type2[byteIndex];
-        size += 1;
-
-        if (VSCP_L1_DATA_SIZE <= size)
-        {
-            break;
-        }
-    }
-
-    txMsg.data[6] = class3;
-    size += 1;
-
-    for(byteIndex = 0; byteIndex < type3Size; ++byteIndex)
-    {
-        txMsg.data[7 + byteIndex] = type3[byteIndex];
-        size += 1;
-
-        if (VSCP_L1_DATA_SIZE <= size)
-        {
-            break;
-        }
-    }
+    txMsg.data[3] = (uint8_t)((type >> 8) & 0xff);
+    txMsg.data[4] = (uint8_t)((type >> 0) & 0xff);
+    size += 2;
 
     txMsg.dataSize = size;
 

--- a/src/events/vscp_evt_protocol.c
+++ b/src/events/vscp_evt_protocol.c
@@ -1196,15 +1196,21 @@ extern BOOL vscp_evt_protocol_sendExtendedPageReadWriteResponse(uint8_t index, u
 /**
  * Get event interest.
  * 
+ * @param[in] nodeAddress Node address.
+ * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendGetEventInterest(void)
+extern BOOL vscp_evt_protocol_sendGetEventInterest(uint8_t nodeAddress)
 {
     vscp_TxMessage  txMsg;
+    uint8_t         size    = 0;
 
     vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_PROTOCOL, VSCP_TYPE_PROTOCOL_GET_EVENT_INTEREST, VSCP_PRIORITY_3_NORMAL);
 
-    txMsg.dataSize = 0;
+    txMsg.data[0] = nodeAddress;
+    size += 1;
+
+    txMsg.dataSize = size;
 
     return vscp_core_sendEvent(&txMsg);
 }

--- a/src/events/vscp_evt_protocol.h
+++ b/src/events/vscp_evt_protocol.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_protocol.h
+++ b/src/events/vscp_evt_protocol.h
@@ -240,22 +240,22 @@ extern BOOL vscp_evt_protocol_sendBlockData(uint8_t const * const data, uint8_t 
 /**
  * ACK data block.
  * 
- * @param[in] blockCrc CRC for block.
- * @param[in] writePointer Write pointer.
+ * @param[in] blockCrc The CRC is calculated over the block data only.
+ * @param[in] blockToWrite The block to write is the block that was sent in the last block data event.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendAckDataBlock(uint16_t blockCrc, uint32_t writePointer);
+extern BOOL vscp_evt_protocol_sendAckDataBlock(uint16_t blockCrc, uint32_t blockToWrite);
 
 /**
  * NACK data block.
  * 
  * @param[in] errorCode User defined error code.
- * @param[in] writePointer Write pointer.
+ * @param[in] blockToWrite The block to write is the block that was sent in the last block data event.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendNackDataBlock(uint8_t errorCode, uint32_t writePointer);
+extern BOOL vscp_evt_protocol_sendNackDataBlock(uint8_t errorCode, uint32_t blockToWrite);
 
 /**
  * Program data block.
@@ -288,7 +288,8 @@ extern BOOL vscp_evt_protocol_sendNackProgramDataBlock(uint8_t errorCode, uint32
 /**
  * Activate new image.
  * 
- * @param[in] crc CRC of full flash data block.
+ * @param[in] crc Sum of all CRC of blocks that was transferred to the node up to this point (all
+ * memory types).
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
@@ -500,18 +501,39 @@ extern BOOL vscp_evt_protocol_sendActivateNewImageAck(void);
 extern BOOL vscp_evt_protocol_sendActivateNewImageNack(void);
 
 /**
- * Block data transfer ACK.
+ * Start block ACK.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendBlockDataTransferAck(void);
+extern BOOL vscp_evt_protocol_sendStartBlockAck(void);
 
 /**
- * Block data transfer NACK.
+ * Start block NACK.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendBlockDataTransferNack(void);
+extern BOOL vscp_evt_protocol_sendStartBlockNack(void);
+
+/**
+ * Block Data Chunk ACK.
+ * 
+ * @return If event is sent, it will return TRUE otherwise FALSE.
+ */
+extern BOOL vscp_evt_protocol_sendBlockDataChunkAck(void);
+
+/**
+ * Block Data Chunk NACK.
+ * 
+ * @return If event is sent, it will return TRUE otherwise FALSE.
+ */
+extern BOOL vscp_evt_protocol_sendBlockDataChunkNack(void);
+
+/**
+ * Bootloader CHECK.
+ * 
+ * @return If event is sent, it will return TRUE otherwise FALSE.
+ */
+extern BOOL vscp_evt_protocol_sendBootloaderCheck(void);
 
 #ifdef __cplusplus
 }

--- a/src/events/vscp_evt_protocol.h
+++ b/src/events/vscp_evt_protocol.h
@@ -471,20 +471,12 @@ extern BOOL vscp_evt_protocol_sendGetEventInterest(void);
  * Get event interest response.
  * 
  * @param[in] index Index.
- * @param[in] classBit9 Class bit 9.
- * @param[in] class1 Class 1.
- * @param[in] type1 Type 1. (array[4])
- * @param[in] type1size Size in byte.
- * @param[in] class2 Class 2.
- * @param[in] type2 Type 2. (array[4])
- * @param[in] type2size Size in byte.
- * @param[in] class3 Class 3.
- * @param[in] type3 Type 3. (array[4])
- * @param[in] type3size Size in byte.
+ * @param[in] class Class.
+ * @param[in] type Type.
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendGetEventInterestResponse(uint8_t index, uint16_t classBit9, uint8_t class1, uint8_t const * const type1, uint8_t type1Size, uint8_t class2, uint8_t const * const type2, uint8_t type2Size, uint8_t class3, uint8_t const * const type3, uint8_t type3Size);
+extern BOOL vscp_evt_protocol_sendGetEventInterestResponse(uint8_t index, uint16_t class, uint16_t type);
 
 /**
  * Activate new image ACK.

--- a/src/events/vscp_evt_protocol.h
+++ b/src/events/vscp_evt_protocol.h
@@ -463,9 +463,11 @@ extern BOOL vscp_evt_protocol_sendExtendedPageReadWriteResponse(uint8_t index, u
 /**
  * Get event interest.
  * 
+ * @param[in] nodeAddress Node address.
+ * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_protocol_sendGetEventInterest(void);
+extern BOOL vscp_evt_protocol_sendGetEventInterest(uint8_t nodeAddress);
 
 /**
  * Get event interest response.

--- a/src/events/vscp_evt_security.c
+++ b/src/events/vscp_evt_security.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_security.h
+++ b/src/events/vscp_evt_security.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_setvaluezone.c
+++ b/src/events/vscp_evt_setvaluezone.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_setvaluezone.c
+++ b/src/events/vscp_evt_setvaluezone.c
@@ -2420,7 +2420,7 @@ extern BOOL vscp_evt_setvaluezone_sendLuminance(uint8_t index, uint8_t zone, uin
 }
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -2431,7 +2431,7 @@ extern BOOL vscp_evt_setvaluezone_sendLuminance(uint8_t index, uint8_t zone, uin
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_setvaluezone_sendChemicalConcentration(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize)
+extern BOOL vscp_evt_setvaluezone_sendChemicalMolarConcentration(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
@@ -2442,7 +2442,7 @@ extern BOOL vscp_evt_setvaluezone_sendChemicalConcentration(uint8_t index, uint8
         return FALSE;
     }
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_SETVALUEZONE, VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_SETVALUEZONE, VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION_MOLAR, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = index;
     size += 1;
@@ -2472,10 +2472,10 @@ extern BOOL vscp_evt_setvaluezone_sendChemicalConcentration(uint8_t index, uint8
     return vscp_core_sendEvent(&txMsg);
 }
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -2486,7 +2486,7 @@ extern BOOL vscp_evt_setvaluezone_sendChemicalConcentration(uint8_t index, uint8
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_setvaluezone_sendDoseEquivalent(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize)
+extern BOOL vscp_evt_setvaluezone_sendReserved(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize)
 {
     vscp_TxMessage  txMsg;
     uint8_t         size    = 0;
@@ -2497,7 +2497,7 @@ extern BOOL vscp_evt_setvaluezone_sendDoseEquivalent(uint8_t index, uint8_t zone
         return FALSE;
     }
 
-    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_SETVALUEZONE, VSCP_TYPE_SETVALUEZONE_DOSE_EQVIVALENT, VSCP_PRIORITY_3_NORMAL);
+    vscp_core_prepareTxMessage(&txMsg, VSCP_CLASS_L1_SETVALUEZONE, VSCP_TYPE_SETVALUEZONE_RESERVED47, VSCP_PRIORITY_3_NORMAL);
 
     txMsg.data[0] = index;
     size += 1;

--- a/src/events/vscp_evt_setvaluezone.h
+++ b/src/events/vscp_evt_setvaluezone.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_setvaluezone.h
+++ b/src/events/vscp_evt_setvaluezone.h
@@ -702,7 +702,7 @@ extern BOOL vscp_evt_setvaluezone_sendLuminousEnergy(uint8_t index, uint8_t zone
 extern BOOL vscp_evt_setvaluezone_sendLuminance(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize);
 
 /**
- * Chemical concentration
+ * Chemical (molar) concentration
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -713,12 +713,12 @@ extern BOOL vscp_evt_setvaluezone_sendLuminance(uint8_t index, uint8_t zone, uin
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_setvaluezone_sendChemicalConcentration(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize);
+extern BOOL vscp_evt_setvaluezone_sendChemicalMolarConcentration(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize);
 
-/* "Reserved" not supported. No frame defined. */
+/* "Chemical (mass) concentration" not supported. No frame defined. */
 
 /**
- * Dose equivalent
+ * Reserved
  * 
  * @param[in] index Index for sensor.
  * @param[in] zone Zone for which event applies to (0-255). 255 is all zones.
@@ -729,7 +729,7 @@ extern BOOL vscp_evt_setvaluezone_sendChemicalConcentration(uint8_t index, uint8
  * 
  * @return If event is sent, it will return TRUE otherwise FALSE.
  */
-extern BOOL vscp_evt_setvaluezone_sendDoseEquivalent(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize);
+extern BOOL vscp_evt_setvaluezone_sendReserved(uint8_t index, uint8_t zone, uint8_t subZone, uint8_t dataCoding, uint8_t const * const data, uint8_t dataSize);
 
 /* "Reserved" not supported. No frame defined. */
 

--- a/src/events/vscp_evt_weather.c
+++ b/src/events/vscp_evt_weather.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_weather.h
+++ b/src/events/vscp_evt_weather.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_weather_forecast.c
+++ b/src/events/vscp_evt_weather_forecast.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_weather_forecast.h
+++ b/src/events/vscp_evt_weather_forecast.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_wireless.c
+++ b/src/events/vscp_evt_wireless.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/events/vscp_evt_wireless.h
+++ b/src/events/vscp_evt_wireless.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_class_l1.h
+++ b/src/vscp_class_l1.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_class_l1_l2.h
+++ b/src/vscp_class_l1_l2.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_config.h
+++ b/src/vscp_config.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_config_base.h
+++ b/src/vscp_config_base.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_core.c
+++ b/src/vscp_core.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_core.c
+++ b/src/vscp_core.c
@@ -1551,6 +1551,18 @@ static inline void  vscp_core_handleProtocolClassType(void)
         /* Boot loader specific event. Not supported. */
         break;
 
+    case VSCP_TYPE_PROTOCOL_BLOCK_CHUNK_ACK:
+        /* Boot loader specific event. Not supported. */
+        break;
+
+    case VSCP_TYPE_PROTOCOL_BLOCK_CHUNK_NACK:
+        /* Boot loader specific event. Not supported. */
+        break;
+
+    case VSCP_TYPE_PROTOCOL_BOOT_LOADER_CHECK:
+        /* Boot loader specific event. Not supported. */
+        break;
+
     /* Not handled type */
     default:
         break;

--- a/src/vscp_core.h
+++ b/src/vscp_core.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_core.h
+++ b/src/vscp_core.h
@@ -93,10 +93,10 @@ extern "C"
 #define VSCP_CORE_VERSION_MAJOR     (1)
 
 /** VSCP specification minor version number, the framework is compliant to. */
-#define VSCP_CORE_VERSION_MINOR     (13)
+#define VSCP_CORE_VERSION_MINOR     (15)
 
 /** VSCP specification sub-minor version number, the framework is compliant to. */
-#define VSCP_CORE_VERSION_SUB_MINOR (1)
+#define VSCP_CORE_VERSION_SUB_MINOR (9)
 
 /** VSCP specification version string, the framework is compliant to. */
 #define VSCP_CORE_VERSION_STR       "v1.15.9"

--- a/src/vscp_core.h
+++ b/src/vscp_core.h
@@ -102,7 +102,7 @@ extern "C"
 #define VSCP_CORE_VERSION_STR       "v1.13.1"
 
 /** VSCP framework version string */
-#define VSCP_CORE_FRAMEWORK_VERSION "v2.0.3"
+#define VSCP_CORE_FRAMEWORK_VERSION "v2.1.0"
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_core.h
+++ b/src/vscp_core.h
@@ -99,7 +99,7 @@ extern "C"
 #define VSCP_CORE_VERSION_SUB_MINOR (1)
 
 /** VSCP specification version string, the framework is compliant to. */
-#define VSCP_CORE_VERSION_STR       "v1.13.1"
+#define VSCP_CORE_VERSION_STR       "v1.15.4"
 
 /** VSCP framework version string */
 #define VSCP_CORE_FRAMEWORK_VERSION "v2.1.0"

--- a/src/vscp_core.h
+++ b/src/vscp_core.h
@@ -99,7 +99,7 @@ extern "C"
 #define VSCP_CORE_VERSION_SUB_MINOR (1)
 
 /** VSCP specification version string, the framework is compliant to. */
-#define VSCP_CORE_VERSION_STR       "v1.15.4"
+#define VSCP_CORE_VERSION_STR       "v1.15.9"
 
 /** VSCP framework version string */
 #define VSCP_CORE_FRAMEWORK_VERSION "v2.1.0"

--- a/src/vscp_data_coding.c
+++ b/src/vscp_data_coding.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_data_coding.h
+++ b/src/vscp_data_coding.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_dev_data.c
+++ b/src/vscp_dev_data.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_dev_data.h
+++ b/src/vscp_dev_data.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_dev_data_config.h
+++ b/src/vscp_dev_data_config.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_dm.c
+++ b/src/vscp_dm.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_dm.h
+++ b/src/vscp_dm.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_dm_ng.c
+++ b/src/vscp_dm_ng.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_dm_ng.h
+++ b/src/vscp_dm_ng.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_logger.c
+++ b/src/vscp_logger.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_logger.h
+++ b/src/vscp_logger.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_ps.c
+++ b/src/vscp_ps.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_ps.h
+++ b/src/vscp_ps.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_transport.c
+++ b/src/vscp_transport.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_transport.h
+++ b/src/vscp_transport.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_alarm.h
+++ b/src/vscp_type_alarm.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_aol.h
+++ b/src/vscp_type_aol.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_configuration.h
+++ b/src/vscp_type_configuration.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_control.h
+++ b/src/vscp_type_control.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_data.h
+++ b/src/vscp_type_data.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_diagnostic.h
+++ b/src/vscp_type_diagnostic.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_display.h
+++ b/src/vscp_type_display.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_display.h
+++ b/src/vscp_type_display.h
@@ -116,12 +116,12 @@ extern "C"
 /**
  * This event contains information that should be displayed on LED(s) pointed out by zone/sub-zone.
  */
-#define VSCP_TYPE_DISPLAY_SHOW_LED                 48
+#define VSCP_TYPE_DISPLAY_SET_LED                  48
 
 /**
- * This event set the color for LED(s) pointed out by zone/sub-zone.
+ * This event set the color for LED(s) (or similar device) pointed out by zone/sub-zone.
  */
-#define VSCP_TYPE_DISPLAY_SHOW_LED_COLOR           49
+#define VSCP_TYPE_DISPLAY_SET_COLOR                49
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_type_error.h
+++ b/src/vscp_type_error.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_gnss.h
+++ b/src/vscp_type_gnss.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_information.h
+++ b/src/vscp_type_information.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_ir.h
+++ b/src/vscp_type_ir.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_log.h
+++ b/src/vscp_type_log.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_measurement.h
+++ b/src/vscp_type_measurement.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_measurement.h
+++ b/src/vscp_type_measurement.h
@@ -150,14 +150,14 @@ extern "C"
 
 /**
  * Default unit: Joule.
- * Optional unit: KWh (1), Wh(2)
+ * Optional unit: kWh (1), Wh (2), eV (electron volt) (3)
  * This is a measurement of energy.
  */
 #define VSCP_TYPE_MEASUREMENT_ENERGY                       13
 
 /**
  * Default unit: watt.
- * Optional unit: Horse power (1).
+ * Optional unit: Horse power Metric (1), Horse power Imperial (2).
  * This is a measurement of power.
  */
 #define VSCP_TYPE_MEASUREMENT_POWER                        14
@@ -194,7 +194,7 @@ extern "C"
 
 /**
  * Default unit: amperes per meter (H).
- * Optional units: teslas (B) (1)
+ * Optional units: Oersted (Oe) (1)
  * This is a measurement of magnetic field strength.
  */
 #define VSCP_TYPE_MEASUREMENT_MAGNETIC_FIELD_STRENGTH      20
@@ -246,8 +246,9 @@ extern "C"
 
 /**
  * Default unit: cubic meter (m³)
- * Opt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4)
- * where unit 4 is only available for Level II measurement events where units can hold this value.
+ * Opt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4),
+ * millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can
+ * hold this value.
  * This is a measurement of volume.
  */
 #define VSCP_TYPE_MEASUREMENT_VOLUME                       28
@@ -277,13 +278,13 @@ extern "C"
 
 /**
  * Default unit: Meters per second.
- * Optional unit: Kilometers per hour (1) Miles per hour (2)
+ * Optional unit: Kilometers per hour (1), Miles per hour (2)
  * This is a measurement of a speed.
  */
 #define VSCP_TYPE_MEASUREMENT_SPEED                        32
 
 /**
- * Default unit: Meters per second/second (m/s2).
+ * Default unit: Meter per second squared (m/s²).
  * This is a measurement of acceleration.
  */
 #define VSCP_TYPE_MEASUREMENT_ACCELERATION                 33
@@ -339,7 +340,7 @@ extern "C"
 #define VSCP_TYPE_MEASUREMENT_SOUND_RESISTANCE             41
 
 /**
- * Default unit: daraf (f-1).
+ * Default unit: daraf (F-1).
  * This is a measurement of electric elasticity.
  */
 #define VSCP_TYPE_MEASUREMENT_ELECTRIC_ELASTANCE           42
@@ -401,6 +402,7 @@ extern "C"
 
 /**
  * Default unit: square meter (m²)
+ * Opt. unit: are (1), hectare (2), square kilometer (km²)
  * Area in square meter.
  */
 #define VSCP_TYPE_MEASUREMENT_AREA                         52

--- a/src/vscp_type_measurement.h
+++ b/src/vscp_type_measurement.h
@@ -70,179 +70,179 @@ extern "C"
 /**
  * General Event.
  */
-#define VSCP_TYPE_MEASUREMENT_GENERAL                 0
+#define VSCP_TYPE_MEASUREMENT_GENERAL                      0
 
 /**
  * This is a discrete value typical for a count. There is no unit for this measurement just a discrete
  * value.
  */
-#define VSCP_TYPE_MEASUREMENT_COUNT                   1
+#define VSCP_TYPE_MEASUREMENT_COUNT                        1
 
 /**
  * Default unit: Meter.
  * This is a measurement of a length or a distance.
  */
-#define VSCP_TYPE_MEASUREMENT_LENGTH                  2
+#define VSCP_TYPE_MEASUREMENT_LENGTH                       2
 
 /**
  * Default unit: Kilogram.
  * This is a measurement of a mass.
  */
-#define VSCP_TYPE_MEASUREMENT_MASS                    3
+#define VSCP_TYPE_MEASUREMENT_MASS                         3
 
 /**
  * A time measurement.
  * Default unit: Seconds.
  * Opt. unit: (1) Milliseconds. Absolute: (2) y-y-m-d-h-m-s (binary). String: (3) "HHMMSS".
  */
-#define VSCP_TYPE_MEASUREMENT_TIME                    4
+#define VSCP_TYPE_MEASUREMENT_TIME                         4
 
 /**
  * Default unit: Ampere.
  * This is a measurement of an electric current.
  */
-#define VSCP_TYPE_MEASUREMENT_ELECTRIC_CURRENT        5
+#define VSCP_TYPE_MEASUREMENT_ELECTRIC_CURRENT             5
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of a temperature.
  */
-#define VSCP_TYPE_MEASUREMENT_TEMPERATURE             6
+#define VSCP_TYPE_MEASUREMENT_TEMPERATURE                  6
 
 /**
  * Default unit: Mole.
  * This is a measurement of an amount of a substance.
  */
-#define VSCP_TYPE_MEASUREMENT_AMOUNT_OF_SUBSTANCE     7
+#define VSCP_TYPE_MEASUREMENT_AMOUNT_OF_SUBSTANCE          7
 
 /**
  * Default unit: Candela.
  * This is a measurement of luminous intensity.
  */
-#define VSCP_TYPE_MEASUREMENT_INTENSITY_OF_LIGHT      8
+#define VSCP_TYPE_MEASUREMENT_INTENSITY_OF_LIGHT           8
 
 /**
  * Default unit: Hertz.
  * This is a measurement of regular events during a second.
  */
-#define VSCP_TYPE_MEASUREMENT_FREQUENCY               9
+#define VSCP_TYPE_MEASUREMENT_FREQUENCY                    9
 
 /**
  * Default unit: becquerel.
  * Optional unit: curie (1)
  * This is a measurement of rates of things, which happen randomly, or are unpredictable.
  */
-#define VSCP_TYPE_MEASUREMENT_RADIOACTIVITY           10
+#define VSCP_TYPE_MEASUREMENT_RADIOACTIVITY                10
 
 /**
  * Default unit: newton.
  * This is a measurement of force.
  */
-#define VSCP_TYPE_MEASUREMENT_FORCE                   11
+#define VSCP_TYPE_MEASUREMENT_FORCE                        11
 
 /**
  * Default unit: pascal.
  * Opt. unit: bar (1), psi (2)
  * This is a measurement of pressure.
  */
-#define VSCP_TYPE_MEASUREMENT_PRESSURE                12
+#define VSCP_TYPE_MEASUREMENT_PRESSURE                     12
 
 /**
  * Default unit: Joule.
  * Optional unit: KWh (1), Wh(2)
  * This is a measurement of energy.
  */
-#define VSCP_TYPE_MEASUREMENT_ENERGY                  13
+#define VSCP_TYPE_MEASUREMENT_ENERGY                       13
 
 /**
  * Default unit: watt.
  * Optional unit: Horse power (1).
  * This is a measurement of power.
  */
-#define VSCP_TYPE_MEASUREMENT_POWER                   14
+#define VSCP_TYPE_MEASUREMENT_POWER                        14
 
 /**
  * Default unit: coulomb.
  * This is a measurement electrical charge.
  */
-#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_CHARGE       15
+#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_CHARGE            15
 
 /**
  * Default unit: volt.
  * This is a measurement of electrical potential.
  */
-#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_POTENTIAL    16
+#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_POTENTIAL         16
 
 /**
  * Default unit: farad (F).
  * This is a measurement of electric capacitance.
  */
-#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_CAPACITANCE  17
+#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_CAPACITANCE       17
 
 /**
  * Default unit: ohm (Ω).
  * This is a measurement of resistance.
  */
-#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_RESISTANCE   18
+#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_RESISTANCE        18
 
 /**
  * Default unit: siemens.
  * This is a measurement of electrical conductance.
  */
-#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_CONDUCTANCE  19
+#define VSCP_TYPE_MEASUREMENT_ELECTRICAL_CONDUCTANCE       19
 
 /**
  * Default unit: amperes per meter (H).
  * Optional units: teslas (B) (1)
  * This is a measurement of magnetic field strength.
  */
-#define VSCP_TYPE_MEASUREMENT_MAGNETIC_FIELD_STRENGTH 20
+#define VSCP_TYPE_MEASUREMENT_MAGNETIC_FIELD_STRENGTH      20
 
 /**
  * Default unit: weber (Wb).
  * This is a measurement of magnetic flux.
  */
-#define VSCP_TYPE_MEASUREMENT_MAGNETIC_FLUX           21
+#define VSCP_TYPE_MEASUREMENT_MAGNETIC_FLUX                21
 
 /**
  * Default unit: tesla (B).
+ * Optional units: Gauss (1)
  * This is a measurement of flux density or field strength for magnetic fields (also called the
  * magnetic induction).
  */
-#define VSCP_TYPE_MEASUREMENT_MAGNETIC_FLUX_DENSITY   22
+#define VSCP_TYPE_MEASUREMENT_MAGNETIC_FLUX_DENSITY        22
 
 /**
  * Default unit: henry (H).
  * This is a measurement of inductance.
  */
-#define VSCP_TYPE_MEASUREMENT_INDUCTANCE              23
+#define VSCP_TYPE_MEASUREMENT_INDUCTANCE                   23
 
 /**
  * Default unit: Lumen (lm= cd * sr)
  * This is a measurement of luminous Flux.
  */
-#define VSCP_TYPE_MEASUREMENT_FLUX_OF_LIGHT           24
+#define VSCP_TYPE_MEASUREMENT_FLUX_OF_LIGHT                24
 
 /**
  * Default unit: lux (lx) ( lx = lm / m² )
  * This is used to express both Illuminance (incidence of light) and Luminous Emittance (emission of
  * light).
  */
-#define VSCP_TYPE_MEASUREMENT_ILLUMINANCE             25
+#define VSCP_TYPE_MEASUREMENT_ILLUMINANCE                  25
 
 /**
  * Default unit: gray (Gy).
- * Opt unit: sievert (Sv) (1).
  * This is a measurement of a radiation dose (Absorbed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT_RADIATION_DOSE          26
+#define VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_ABSORBED      26
 
 /**
- * Default unit: katal (z).
+ * Default unit: katal (kat).
  * This is a measurement of catalytic activity used in biochemistry.
  */
-#define VSCP_TYPE_MEASUREMENT_CATALYTIC_ACITIVITY     27
+#define VSCP_TYPE_MEASUREMENT_CATALYTIC_ACITIVITY          27
 
 /**
  * Default unit: cubic meter (m³)
@@ -250,13 +250,13 @@ extern "C"
  * where unit 4 is only available for Level II measurement events where units can hold this value.
  * This is a measurement of volume.
  */
-#define VSCP_TYPE_MEASUREMENT_VOLUME                  28
+#define VSCP_TYPE_MEASUREMENT_VOLUME                       28
 
 /**
  * Default unit: W/m2, watt per square meter.
  * This is a measurement of sound intensity (acoustic intensity).
  */
-#define VSCP_TYPE_MEASUREMENT_SOUND_INTENSITY         29
+#define VSCP_TYPE_MEASUREMENT_SOUND_INTENSITY              29
 
 /**
  * Default unit: radian (rad) (Plane angles).
@@ -265,162 +265,163 @@ extern "C"
  * Opt Unit: arcseconds (3).
  * This is a measurement of an angle or a direction or similar.
  */
-#define VSCP_TYPE_MEASUREMENT_ANGLE                   30
+#define VSCP_TYPE_MEASUREMENT_ANGLE                        30
 
 /**
  * Default unit: Longitude.
  * Opt. unit: Latitude.
- * This is a measurement of a position as of WGS 84. Normally given as a floating point value. See
- * ./class1.gps.md for a better candidate to use for position data.
+ * This is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point
+ * value. See ./class1.gps.md for a better candidate to use for position data.
  */
-#define VSCP_TYPE_MEASUREMENT_POSITION                31
+#define VSCP_TYPE_MEASUREMENT_POSITION                     31
 
 /**
  * Default unit: Meters per second.
  * Optional unit: Kilometers per hour (1) Miles per hour (2)
  * This is a measurement of a speed.
  */
-#define VSCP_TYPE_MEASUREMENT_SPEED                   32
+#define VSCP_TYPE_MEASUREMENT_SPEED                        32
 
 /**
  * Default unit: Meters per second/second (m/s2).
  * This is a measurement of acceleration.
  */
-#define VSCP_TYPE_MEASUREMENT_ACCELERATION            33
+#define VSCP_TYPE_MEASUREMENT_ACCELERATION                 33
 
 /**
  * Default unit: N/m.
  * This is a measurement of tension.
  */
-#define VSCP_TYPE_MEASUREMENT_TENSION                 34
+#define VSCP_TYPE_MEASUREMENT_TENSION                      34
 
 /**
  * Default unit: Relative percentage 0-100%.
  * This is a measurement of relative moistness (Humidity).
  */
-#define VSCP_TYPE_MEASUREMENT_HUMIDITY                35
+#define VSCP_TYPE_MEASUREMENT_HUMIDITY                     35
 
 /**
  * Default unit: Cubic meters/second.
  * Opt Unit: Liters/Second.
  * This is a measurement of flow.
  */
-#define VSCP_TYPE_MEASUREMENT_FLOW                    36
+#define VSCP_TYPE_MEASUREMENT_FLOW                         36
 
 /**
  * Default unit: Thermal ohm K/W.
  * This is a measurement of thermal resistance.
  */
-#define VSCP_TYPE_MEASUREMENT_THERMAL_RESISTANCE      37
+#define VSCP_TYPE_MEASUREMENT_THERMAL_RESISTANCE           37
 
 /**
  * Default unit: dioptre (dpt) m-1.
  * This is a measurement of refractive (optical) power.
  */
-#define VSCP_TYPE_MEASUREMENT_REFRACTIVE_POWER        38
+#define VSCP_TYPE_MEASUREMENT_REFRACTIVE_POWER             38
 
 /**
- * Default unit: poiseuille (Pl)
+ * Default unit: pascal second
+ * Optional units: poiseuille (Pl) = 1, poise (P) = 2
  * This is a measurement of dynamic viscosity.
  */
-#define VSCP_TYPE_MEASUREMENT_DYNAMIC_VISCOSITY       39
+#define VSCP_TYPE_MEASUREMENT_DYNAMIC_VISCOSITY            39
 
 /**
  * Default unit: rayl (Pa·s/m)
  * This is a measurement of sound impedance.
  */
-#define VSCP_TYPE_MEASUREMENT_SOUND_IMPEDANCE         40
+#define VSCP_TYPE_MEASUREMENT_SOUND_IMPEDANCE              40
 
 /**
  * Default unit: Acoustic ohm Pa · s/ m³.
  * This is a measurement of sound resistance.
  */
-#define VSCP_TYPE_MEASUREMENT_SOUND_RESISTANCE        41
+#define VSCP_TYPE_MEASUREMENT_SOUND_RESISTANCE             41
 
 /**
  * Default unit: daraf (f-1).
  * This is a measurement of electric elasticity.
  */
-#define VSCP_TYPE_MEASUREMENT_ELECTRIC_ELASTANCE      42
+#define VSCP_TYPE_MEASUREMENT_ELECTRIC_ELASTANCE           42
 
 /**
  * Default unit: talbot ( tb = lm * s)
  * This is a measurement of luminous energy.
  */
-#define VSCP_TYPE_MEASUREMENT_LUMINOUS_ENERGY         43
+#define VSCP_TYPE_MEASUREMENT_LUMINOUS_ENERGY              43
 
 /**
  * Default unit: cd / m²) (non SI unit = nit)
  * This is a measurement of luminance.
  */
-#define VSCP_TYPE_MEASUREMENT_LUMINANCE               44
+#define VSCP_TYPE_MEASUREMENT_LUMINANCE                    44
 
 /**
- * Default unit: molal (mol/kg).
- * This is a measurement of chemical concentration.
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mol/ppm/percent concentration.
  */
-#define VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION  45
+#define VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION_MOLAR 45
 
 /**
- * Reserved (previously was doublet of Type= 26, don't use any longer!)
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mass concentration.
  */
-#define VSCP_TYPE_MEASUREMENT_RESERVED46              46
+#define VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION_MASS  46
 
 /**
- * Default unit: sievert (J/Kg).
- * This is a measurement of dose equivalent.
+ * Reserved.
  */
-#define VSCP_TYPE_MEASUREMENT_DOSE_EQVIVALENT         47
+#define VSCP_TYPE_MEASUREMENT_RESERVED47                   47
 
 /**
  * Reserved (was doublet of Type= 24, do not use any longer!)
  */
-#define VSCP_TYPE_MEASUREMENT_RESERVED48              48
+#define VSCP_TYPE_MEASUREMENT_RESERVED48                   48
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of the Dew Point.
  */
-#define VSCP_TYPE_MEASUREMENT_DEWPOINT                49
+#define VSCP_TYPE_MEASUREMENT_DEWPOINT                     49
 
 /**
  * Default unit: Relative value.
  * This is a relative value for a level measurement without a unit. It is just relative to the min/max
  * value for the selected data representation, typically percentage or per mille or similar.
  */
-#define VSCP_TYPE_MEASUREMENT_RELATIVE_LEVEL          50
+#define VSCP_TYPE_MEASUREMENT_RELATIVE_LEVEL               50
 
 /**
  * Default unit: Meter.
  * Opt. unit: Feet(1), inches (2)
  * Altitude in meters.
  */
-#define VSCP_TYPE_MEASUREMENT_ALTITUDE                51
+#define VSCP_TYPE_MEASUREMENT_ALTITUDE                     51
 
 /**
  * Default unit: square meter (m²)
  * Area in square meter.
  */
-#define VSCP_TYPE_MEASUREMENT_AREA                    52
+#define VSCP_TYPE_MEASUREMENT_AREA                         52
 
 /**
  * Default unit: watt per steradian ( W / sr )
  * Radiated power per room angle.
  */
-#define VSCP_TYPE_MEASUREMENT_RADIANT_INTENSITY       53
+#define VSCP_TYPE_MEASUREMENT_RADIANT_INTENSITY            53
 
 /**
  * Default unit: watt per steradian per square metre ( W / (sr * m²) )
  * This is the radiant flux emitted, reflected, transmitted or received by a surface.
  */
-#define VSCP_TYPE_MEASUREMENT_RADIANCE                54
+#define VSCP_TYPE_MEASUREMENT_RADIANCE                     54
 
 /**
  * Default unit: watt per square metre ( W / m² )
  * Power emitted from or striking onto a surface or area.
  */
-#define VSCP_TYPE_MEASUREMENT_IRRADIANCE              55
+#define VSCP_TYPE_MEASUREMENT_IRRADIANCE                   55
 
 /**
  * Default unit: watt per steradian per square metre per nm (W·sr-1·m-2·nm-1)
@@ -428,46 +429,46 @@ extern "C"
  * hertz (W·sr-1·m-3) (2)
  * Radiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREMENT_SPECTRAL_RADIANCE       56
+#define VSCP_TYPE_MEASUREMENT_SPECTRAL_RADIANCE            56
 
 /**
  * Default unit: watt per square metre per nm (W·m-2·nm-1)
  * Opt. unit: watt per metre3 (W·m-3) (1), watt per square metre per hertz (W·m-2·Hz-1) (2)
  * Irradiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREMENT_SPECTRAL_IRRADIANCE     57
+#define VSCP_TYPE_MEASUREMENT_SPECTRAL_IRRADIANCE          57
 
 /**
  * Default unit: pascal (Pa)
  * This is a measurement of sound pressure (acoustic pressure).
  */
-#define VSCP_TYPE_MEASUREMENT_SOUND_PRESSURE          58
+#define VSCP_TYPE_MEASUREMENT_SOUND_PRESSURE               58
 
 /**
  * Default unit: pascal (Pa)
  * Sound energy density or sound density is the sound energy per unit volume.
  */
-#define VSCP_TYPE_MEASUREMENT_SOUND_DENSITY           59
+#define VSCP_TYPE_MEASUREMENT_SOUND_DENSITY                59
 
 /**
  * Default unit: decibel (dB)
  * Sound level expressed in decibel. This event is supplied for convenience.
  */
-#define VSCP_TYPE_MEASUREMENT_SOUND_LEVEL             60
+#define VSCP_TYPE_MEASUREMENT_SOUND_LEVEL                  60
 
 /**
  * Default unit: sievert (Sv).
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_EQ       61
+#define VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_EQ            61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).
  * Optional unit: Röntgen/R (1)
  * This is a measurement of a radiation dose (Exposed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_EXPOSURE 62
+#define VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_EXPOSURE      62
 
 /**
  * Default unit: cos of phase angle.
@@ -475,7 +476,7 @@ extern "C"
  * usually expressed as a percentage - and the lower the percentage, the less efficient power usage
  * is.
  */
-#define VSCP_TYPE_MEASUREMENT_POWER_FACTOR            63
+#define VSCP_TYPE_MEASUREMENT_POWER_FACTOR                 63
 
 /**
  * Default unit: VAr
@@ -483,14 +484,14 @@ extern "C"
  * measurement of reactive power. Reactive power exists in AC circuit when the current and voltage are
  * not in phase.
  */
-#define VSCP_TYPE_MEASUREMENT_REACTIVE_POWER          64
+#define VSCP_TYPE_MEASUREMENT_REACTIVE_POWER               64
 
 /**
  * Default unit: kVArh
  * Reactive energy is the electrical energy produced, flowing or supplied by an electric circuit
  * during a time interval, measured in units of kVArh or standard multiples thereof.
  */
-#define VSCP_TYPE_MEASUREMENT_REACTIVE_ENERGY         65
+#define VSCP_TYPE_MEASUREMENT_REACTIVE_ENERGY              65
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_type_measurement.h
+++ b/src/vscp_type_measurement.h
@@ -461,7 +461,7 @@ extern "C"
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_EQ            61
+#define VSCP_TYPE_MEASUREMENT_DOSE_EQUIVALENT              61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).

--- a/src/vscp_type_measurement32.h
+++ b/src/vscp_type_measurement32.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_measurement32.h
+++ b/src/vscp_type_measurement32.h
@@ -69,179 +69,179 @@ extern "C"
 /**
  * General Event.
  */
-#define VSCP_TYPE_MEASUREMENT32_GENERAL                 0
+#define VSCP_TYPE_MEASUREMENT32_GENERAL                      0
 
 /**
  * This is a discrete value typical for a count. There is no unit for this measurement just a discrete
  * value.
  */
-#define VSCP_TYPE_MEASUREMENT32_COUNT                   1
+#define VSCP_TYPE_MEASUREMENT32_COUNT                        1
 
 /**
  * Default unit: Meter.
  * This is a measurement of a length or a distance.
  */
-#define VSCP_TYPE_MEASUREMENT32_LENGTH                  2
+#define VSCP_TYPE_MEASUREMENT32_LENGTH                       2
 
 /**
  * Default unit: Kilogram.
  * This is a measurement of a mass.
  */
-#define VSCP_TYPE_MEASUREMENT32_MASS                    3
+#define VSCP_TYPE_MEASUREMENT32_MASS                         3
 
 /**
  * A time measurement.
  * Default unit: Seconds.
  * Opt. unit: (1) Milliseconds. Absolute: (2) y-y-m-d-h-m-s (binary). String: (3) "HHMMSS".
  */
-#define VSCP_TYPE_MEASUREMENT32_TIME                    4
+#define VSCP_TYPE_MEASUREMENT32_TIME                         4
 
 /**
  * Default unit: Ampere.
  * This is a measurement of an electric current.
  */
-#define VSCP_TYPE_MEASUREMENT32_ELECTRIC_CURRENT        5
+#define VSCP_TYPE_MEASUREMENT32_ELECTRIC_CURRENT             5
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of a temperature.
  */
-#define VSCP_TYPE_MEASUREMENT32_TEMPERATURE             6
+#define VSCP_TYPE_MEASUREMENT32_TEMPERATURE                  6
 
 /**
  * Default unit: Mole.
  * This is a measurement of an amount of a substance.
  */
-#define VSCP_TYPE_MEASUREMENT32_AMOUNT_OF_SUBSTANCE     7
+#define VSCP_TYPE_MEASUREMENT32_AMOUNT_OF_SUBSTANCE          7
 
 /**
  * Default unit: Candela.
  * This is a measurement of luminous intensity.
  */
-#define VSCP_TYPE_MEASUREMENT32_INTENSITY_OF_LIGHT      8
+#define VSCP_TYPE_MEASUREMENT32_INTENSITY_OF_LIGHT           8
 
 /**
  * Default unit: Hertz.
  * This is a measurement of regular events during a second.
  */
-#define VSCP_TYPE_MEASUREMENT32_FREQUENCY               9
+#define VSCP_TYPE_MEASUREMENT32_FREQUENCY                    9
 
 /**
  * Default unit: becquerel.
  * Optional unit: curie (1)
  * This is a measurement of rates of things, which happen randomly, or are unpredictable.
  */
-#define VSCP_TYPE_MEASUREMENT32_RADIOACTIVITY           10
+#define VSCP_TYPE_MEASUREMENT32_RADIOACTIVITY                10
 
 /**
  * Default unit: newton.
  * This is a measurement of force.
  */
-#define VSCP_TYPE_MEASUREMENT32_FORCE                   11
+#define VSCP_TYPE_MEASUREMENT32_FORCE                        11
 
 /**
  * Default unit: pascal.
  * Opt. unit: bar (1), psi (2)
  * This is a measurement of pressure.
  */
-#define VSCP_TYPE_MEASUREMENT32_PRESSURE                12
+#define VSCP_TYPE_MEASUREMENT32_PRESSURE                     12
 
 /**
  * Default unit: Joule.
  * Optional unit: KWh (1)
  * This is a measurement of energy.
  */
-#define VSCP_TYPE_MEASUREMENT32_ENERGY                  13
+#define VSCP_TYPE_MEASUREMENT32_ENERGY                       13
 
 /**
  * Default unit: watt.
  * Optional unit: Horse power (1).
  * This is a measurement of power.
  */
-#define VSCP_TYPE_MEASUREMENT32_POWER                   14
+#define VSCP_TYPE_MEASUREMENT32_POWER                        14
 
 /**
  * Default unit: coulomb.
  * This is a measurement electrical charge.
  */
-#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_CHARGE       15
+#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_CHARGE            15
 
 /**
  * Default unit: volt.
  * This is a measurement of electrical potential.
  */
-#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_POTENTIAL    16
+#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_POTENTIAL         16
 
 /**
  * Default unit: farad (F).
  * This is a measurement of electric capacitance.
  */
-#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_CAPACITANCE  17
+#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_CAPACITANCE       17
 
 /**
  * Default unit: ohm (Ω).
  * This is a measurement of resistance.
  */
-#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_RESISTANCE   18
+#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_RESISTANCE        18
 
 /**
  * Default unit: siemens.
  * This is a measurement of electrical conductance.
  */
-#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_CONDUCTANCE  19
+#define VSCP_TYPE_MEASUREMENT32_ELECTRICAL_CONDUCTANCE       19
 
 /**
  * Default unit: amperes per meter (H).
  * Optional units: teslas (B) (1)
  * This is a measurement of magnetic field strength.
  */
-#define VSCP_TYPE_MEASUREMENT32_MAGNETIC_FIELD_STRENGTH 20
+#define VSCP_TYPE_MEASUREMENT32_MAGNETIC_FIELD_STRENGTH      20
 
 /**
  * Default unit: weber (Wb).
  * This is a measurement of magnetic flux.
  */
-#define VSCP_TYPE_MEASUREMENT32_MAGNETIC_FLUX           21
+#define VSCP_TYPE_MEASUREMENT32_MAGNETIC_FLUX                21
 
 /**
  * Default unit: tesla (B).
+ * Optional units: Gauss (1)
  * This is a measurement of flux density or field strength for magnetic fields (also called the
  * magnetic induction).
  */
-#define VSCP_TYPE_MEASUREMENT32_MAGNETIC_FLUX_DENSITY   22
+#define VSCP_TYPE_MEASUREMENT32_MAGNETIC_FLUX_DENSITY        22
 
 /**
  * Default unit: henry (H).
  * This is a measurement of inductance.
  */
-#define VSCP_TYPE_MEASUREMENT32_INDUCTANCE              23
+#define VSCP_TYPE_MEASUREMENT32_INDUCTANCE                   23
 
 /**
  * Default unit: Lumen (lm= cd * sr)
  * This is a measurement of luminous Flux.
  */
-#define VSCP_TYPE_MEASUREMENT32_FLUX_OF_LIGHT           24
+#define VSCP_TYPE_MEASUREMENT32_FLUX_OF_LIGHT                24
 
 /**
  * Default unit: lux (lx) ( lx = lm / m² )
  * This is used to express both Illuminance (incidence of light) and Luminous Emittance (emission of
  * light).
  */
-#define VSCP_TYPE_MEASUREMENT32_ILLUMINANCE             25
+#define VSCP_TYPE_MEASUREMENT32_ILLUMINANCE                  25
 
 /**
  * Default unit: gray (Gy).
- * Opt unit: sievert (Sv) (1).
  * This is a measurement of a radiation dose (Absorbed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE          26
+#define VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_ABSORBED      26
 
 /**
- * Default unit: katal (z).
+ * Default unit: katal (kat).
  * This is a measurement of catalytic activity used in biochemistry.
  */
-#define VSCP_TYPE_MEASUREMENT32_CATALYTIC_ACITIVITY     27
+#define VSCP_TYPE_MEASUREMENT32_CATALYTIC_ACITIVITY          27
 
 /**
  * Default unit: cubic meter (m³)
@@ -249,13 +249,13 @@ extern "C"
  * where unit 4 is only available for Level II measurement events where units can hold this value.
  * This is a measurement of volume.
  */
-#define VSCP_TYPE_MEASUREMENT32_VOLUME                  28
+#define VSCP_TYPE_MEASUREMENT32_VOLUME                       28
 
 /**
  * Default unit: W/m2, watt per square meter.
  * This is a measurement of sound intensity (acoustic intensity).
  */
-#define VSCP_TYPE_MEASUREMENT32_SOUND_INTENSITY         29
+#define VSCP_TYPE_MEASUREMENT32_SOUND_INTENSITY              29
 
 /**
  * Default unit: radian (rad) (Plane angles).
@@ -264,162 +264,163 @@ extern "C"
  * Opt Unit: arcseconds (3).
  * This is a measurement of an angle.
  */
-#define VSCP_TYPE_MEASUREMENT32_ANGLE                   30
+#define VSCP_TYPE_MEASUREMENT32_ANGLE                        30
 
 /**
  * Default unit: Longitude.
  * Opt. unit: Latitude.
- * This is a measurement of a position as of WGS 84. Normally given as a floating point value. See
- * ./class1.gps.md for a better candidate to use for position data.
+ * This is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point
+ * value. See ./class1.gps.md for a better candidate to use for position data.
  */
-#define VSCP_TYPE_MEASUREMENT32_POSITION                31
+#define VSCP_TYPE_MEASUREMENT32_POSITION                     31
 
 /**
  * Default unit: Meters per second.
  * Optional unit: Kilometers per hour (1) Miles per hour (2)
  * This is a measurement of a speed.
  */
-#define VSCP_TYPE_MEASUREMENT32_SPEED                   32
+#define VSCP_TYPE_MEASUREMENT32_SPEED                        32
 
 /**
  * Default unit: Meters per second/second (m/s2).
  * This is a measurement of acceleration.
  */
-#define VSCP_TYPE_MEASUREMENT32_ACCELERATION            33
+#define VSCP_TYPE_MEASUREMENT32_ACCELERATION                 33
 
 /**
  * Default unit: N/m.
  * This is a measurement of tension.
  */
-#define VSCP_TYPE_MEASUREMENT32_TENSION                 34
+#define VSCP_TYPE_MEASUREMENT32_TENSION                      34
 
 /**
  * Default unit: Relative percentage 0-100%.
  * This is a measurement of relative moistness (Humidity).
  */
-#define VSCP_TYPE_MEASUREMENT32_HUMIDITY                35
+#define VSCP_TYPE_MEASUREMENT32_HUMIDITY                     35
 
 /**
  * Default unit: Cubic meters/second.
  * Opt Unit: Liters/Second.
  * This is a measurement of flow.
  */
-#define VSCP_TYPE_MEASUREMENT32_FLOW                    36
+#define VSCP_TYPE_MEASUREMENT32_FLOW                         36
 
 /**
  * Default unit: Thermal ohm K/W.
  * This is a measurement of thermal resistance.
  */
-#define VSCP_TYPE_MEASUREMENT32_THERMAL_RESISTANCE      37
+#define VSCP_TYPE_MEASUREMENT32_THERMAL_RESISTANCE           37
 
 /**
  * Default unit: dioptre (dpt) m-1.
  * This is a measurement of refractive (optical) power.
  */
-#define VSCP_TYPE_MEASUREMENT32_REFRACTIVE_POWER        38
+#define VSCP_TYPE_MEASUREMENT32_REFRACTIVE_POWER             38
 
 /**
- * Default unit: poiseuille (Pl)
+ * Default unit: pascal second
+ * Optional units: poiseuille (Pl) = 1, poise (P) = 2
  * This is a measurement of dynamic viscosity.
  */
-#define VSCP_TYPE_MEASUREMENT32_DYNAMIC_VISCOSITY       39
+#define VSCP_TYPE_MEASUREMENT32_DYNAMIC_VISCOSITY            39
 
 /**
  * Default unit: rayl (Pa·s/m)
  * This is a measurement of sound impedance.
  */
-#define VSCP_TYPE_MEASUREMENT32_SOUND_IMPEDANCE         40
+#define VSCP_TYPE_MEASUREMENT32_SOUND_IMPEDANCE              40
 
 /**
  * Default unit: Acoustic ohm Pa · s/ m³.
  * This is a measurement of sound resistance.
  */
-#define VSCP_TYPE_MEASUREMENT32_SOUND_RESISTANCE        41
+#define VSCP_TYPE_MEASUREMENT32_SOUND_RESISTANCE             41
 
 /**
  * Default unit: daraf (f-1).
  * This is a measurement of electric elasticity.
  */
-#define VSCP_TYPE_MEASUREMENT32_ELECTRIC_ELASTANCE      42
+#define VSCP_TYPE_MEASUREMENT32_ELECTRIC_ELASTANCE           42
 
 /**
  * Default unit: talbot ( tb = lm * s)
  * This is a measurement of luminous energy.
  */
-#define VSCP_TYPE_MEASUREMENT32_LUMINOUS_ENERGY         43
+#define VSCP_TYPE_MEASUREMENT32_LUMINOUS_ENERGY              43
 
 /**
  * Default unit: cd / m²) (non SI unit = nit)
  * This is a measurement of luminance.
  */
-#define VSCP_TYPE_MEASUREMENT32_LUMINANCE               44
+#define VSCP_TYPE_MEASUREMENT32_LUMINANCE                    44
 
 /**
- * Default unit: molal (mol/kg).
- * This is a measurement of chemical concentration.
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mol/ppm/percent concentration.
  */
-#define VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION  45
+#define VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION_MOLAR 45
 
 /**
- * Reserved (previously was doublet of Type= 26, don't use any longer!)
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mass concentration.
  */
-#define VSCP_TYPE_MEASUREMENT32_RESERVED46              46
+#define VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION_MASS  46
 
 /**
- * Default unit: sievert (J/Kg).
- * This is a measurement of dose equivalent.
+ * Reserved.
  */
-#define VSCP_TYPE_MEASUREMENT32_DOSE_EQVIVALENT         47
+#define VSCP_TYPE_MEASUREMENT32_RESERVED47                   47
 
 /**
  * Reserved (was doublet of Type= 24, do not use any longer!)
  */
-#define VSCP_TYPE_MEASUREMENT32_RESERVED48              48
+#define VSCP_TYPE_MEASUREMENT32_RESERVED48                   48
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of the Dew Point.
  */
-#define VSCP_TYPE_MEASUREMENT32_DEWPOINT                49
+#define VSCP_TYPE_MEASUREMENT32_DEWPOINT                     49
 
 /**
  * Default unit: Relative value.
  * This is a relative value for a level measurement without a unit. It is just relative to the min/max
  * value for the selected data representation, typically percentage or per mille or similar.
  */
-#define VSCP_TYPE_MEASUREMENT32_RELATIVE_LEVEL          50
+#define VSCP_TYPE_MEASUREMENT32_RELATIVE_LEVEL               50
 
 /**
  * Default unit: Meter.
  * Opt. unit: Feet(1), inches (2)
  * Altitude in meters.
  */
-#define VSCP_TYPE_MEASUREMENT32_ALTITUDE                51
+#define VSCP_TYPE_MEASUREMENT32_ALTITUDE                     51
 
 /**
  * Default unit: square meter (m²)
  * Area in square meter.
  */
-#define VSCP_TYPE_MEASUREMENT32_AREA                    52
+#define VSCP_TYPE_MEASUREMENT32_AREA                         52
 
 /**
  * Default unit: watt per steradian ( W / sr )
  * Radiated power per room angle.
  */
-#define VSCP_TYPE_MEASUREMENT32_RADIANT_INTENSITY       53
+#define VSCP_TYPE_MEASUREMENT32_RADIANT_INTENSITY            53
 
 /**
  * Default unit: watt per steradian per square metre ( W / (sr * m²) )
  * This is the radiant flux emitted, reflected, transmitted or received by a surface.
  */
-#define VSCP_TYPE_MEASUREMENT32_RADIANCE                54
+#define VSCP_TYPE_MEASUREMENT32_RADIANCE                     54
 
 /**
  * Default unit: watt per square metre ( W / m² )
  * Power emitted from or striking onto a surface or area.
  */
-#define VSCP_TYPE_MEASUREMENT32_IRRADIANCE              55
+#define VSCP_TYPE_MEASUREMENT32_IRRADIANCE                   55
 
 /**
  * Default unit: watt per steradian per square metre per nm (W·sr-1·m-2·nm-1)
@@ -427,46 +428,46 @@ extern "C"
  * hertz (W·sr-1·m-3) (2)
  * Radiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREMENT32_SPECTRAL_RADIANCE       56
+#define VSCP_TYPE_MEASUREMENT32_SPECTRAL_RADIANCE            56
 
 /**
  * Default unit: watt per square metre per nm (W·m-2·nm-1)
  * Opt. unit: watt per metre3 (W·m-3) (1), watt per square metre per hertz (W·m-2·Hz-1) (2)
  * Irradiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREMENT32_SPECTRAL_IRRADIANCE     57
+#define VSCP_TYPE_MEASUREMENT32_SPECTRAL_IRRADIANCE          57
 
 /**
  * Default unit: pascal (Pa)
  * This is a measurement of sound pressure (acoustic pressure).
  */
-#define VSCP_TYPE_MEASUREMENT32_SOUND_PRESSURE          58
+#define VSCP_TYPE_MEASUREMENT32_SOUND_PRESSURE               58
 
 /**
  * Default unit: pascal (Pa)
  * Sound energy density or sound density is the sound energy per unit volume.
  */
-#define VSCP_TYPE_MEASUREMENT32_SOUND_DENSITY           59
+#define VSCP_TYPE_MEASUREMENT32_SOUND_DENSITY                59
 
 /**
  * Default unit: decibel (dB)
  * Sound level expressed in decibel. This event is supplied for convenience.
  */
-#define VSCP_TYPE_MEASUREMENT32_SOUND_LEVEL             60
+#define VSCP_TYPE_MEASUREMENT32_SOUND_LEVEL                  60
 
 /**
  * Default unit: sievert (Sv).
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_EQ       61
+#define VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_EQ            61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).
  * Optional unit: Röntgen/R (1)
  * This is a measurement of a radiation dose (Exposed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_EXPOSURE 62
+#define VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_EXPOSURE      62
 
 /**
  * Default unit: cos of phase angle.
@@ -474,7 +475,7 @@ extern "C"
  * usually expressed as a percentage - and the lower the percentage, the less efficient power usage
  * is.
  */
-#define VSCP_TYPE_MEASUREMENT32_POWER_FACTOR            63
+#define VSCP_TYPE_MEASUREMENT32_POWER_FACTOR                 63
 
 /**
  * Default unit: VAr
@@ -482,14 +483,14 @@ extern "C"
  * measurement of reactive power. Reactive power exists in AC circuit when the current and voltage are
  * not in phase.
  */
-#define VSCP_TYPE_MEASUREMENT32_REACTIVE_POWER          64
+#define VSCP_TYPE_MEASUREMENT32_REACTIVE_POWER               64
 
 /**
  * Default unit: kVArh
  * Reactive energy is the electrical energy produced, flowing or supplied by an electric circuit
  * during a time interval, measured in units of kVArh or standard multiples thereof.
  */
-#define VSCP_TYPE_MEASUREMENT32_REACTIVE_ENERGY         65
+#define VSCP_TYPE_MEASUREMENT32_REACTIVE_ENERGY              65
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_type_measurement32.h
+++ b/src/vscp_type_measurement32.h
@@ -460,7 +460,7 @@ extern "C"
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_EQ            61
+#define VSCP_TYPE_MEASUREMENT32_DOSE_EQUIVALENT              61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).

--- a/src/vscp_type_measurement32.h
+++ b/src/vscp_type_measurement32.h
@@ -149,14 +149,14 @@ extern "C"
 
 /**
  * Default unit: Joule.
- * Optional unit: KWh (1)
+ * Optional unit: kWh (1), Wh (2), eV (electron volt) (3)
  * This is a measurement of energy.
  */
 #define VSCP_TYPE_MEASUREMENT32_ENERGY                       13
 
 /**
  * Default unit: watt.
- * Optional unit: Horse power (1).
+ * Optional unit: Horse power Metric (1), Horse power Imperial (2).
  * This is a measurement of power.
  */
 #define VSCP_TYPE_MEASUREMENT32_POWER                        14
@@ -193,7 +193,7 @@ extern "C"
 
 /**
  * Default unit: amperes per meter (H).
- * Optional units: teslas (B) (1)
+ * Optional units: Oersted (Oe) (1)
  * This is a measurement of magnetic field strength.
  */
 #define VSCP_TYPE_MEASUREMENT32_MAGNETIC_FIELD_STRENGTH      20
@@ -245,8 +245,9 @@ extern "C"
 
 /**
  * Default unit: cubic meter (m³)
- * Opt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4)
- * where unit 4 is only available for Level II measurement events where units can hold this value.
+ * Opt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4),
+ * millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can
+ * hold this value.
  * This is a measurement of volume.
  */
 #define VSCP_TYPE_MEASUREMENT32_VOLUME                       28
@@ -276,13 +277,13 @@ extern "C"
 
 /**
  * Default unit: Meters per second.
- * Optional unit: Kilometers per hour (1) Miles per hour (2)
+ * Optional unit: Kilometers per hour (1), Miles per hour (2)
  * This is a measurement of a speed.
  */
 #define VSCP_TYPE_MEASUREMENT32_SPEED                        32
 
 /**
- * Default unit: Meters per second/second (m/s2).
+ * Default unit: Meter per second squared (m/s²).
  * This is a measurement of acceleration.
  */
 #define VSCP_TYPE_MEASUREMENT32_ACCELERATION                 33
@@ -338,7 +339,7 @@ extern "C"
 #define VSCP_TYPE_MEASUREMENT32_SOUND_RESISTANCE             41
 
 /**
- * Default unit: daraf (f-1).
+ * Default unit: daraf (F-1).
  * This is a measurement of electric elasticity.
  */
 #define VSCP_TYPE_MEASUREMENT32_ELECTRIC_ELASTANCE           42
@@ -400,6 +401,7 @@ extern "C"
 
 /**
  * Default unit: square meter (m²)
+ * Opt. unit: are (1), hectare (2), square kilometer (km²)
  * Area in square meter.
  */
 #define VSCP_TYPE_MEASUREMENT32_AREA                         52

--- a/src/vscp_type_measurement64.h
+++ b/src/vscp_type_measurement64.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_measurement64.h
+++ b/src/vscp_type_measurement64.h
@@ -69,179 +69,179 @@ extern "C"
 /**
  * General Event.
  */
-#define VSCP_TYPE_MEASUREMENT64_GENERAL                 0
+#define VSCP_TYPE_MEASUREMENT64_GENERAL                      0
 
 /**
  * This is a discrete value typical for a count. There is no unit for this measurement just a discrete
  * value.
  */
-#define VSCP_TYPE_MEASUREMENT64_COUNT                   1
+#define VSCP_TYPE_MEASUREMENT64_COUNT                        1
 
 /**
  * Default unit: Meter.
  * This is a measurement of a length or a distance.
  */
-#define VSCP_TYPE_MEASUREMENT64_LENGTH                  2
+#define VSCP_TYPE_MEASUREMENT64_LENGTH                       2
 
 /**
  * Default unit: Kilogram.
  * This is a measurement of a mass.
  */
-#define VSCP_TYPE_MEASUREMENT64_MASS                    3
+#define VSCP_TYPE_MEASUREMENT64_MASS                         3
 
 /**
  * A time measurement.
  * Default unit: Seconds.
  * Opt. unit: (1) Milliseconds. Absolute: (2) y-y-m-d-h-m-s (binary). String: (3) "HHMMSS".
  */
-#define VSCP_TYPE_MEASUREMENT64_TIME                    4
+#define VSCP_TYPE_MEASUREMENT64_TIME                         4
 
 /**
  * Default unit: Ampere.
  * This is a measurement of an electric current.
  */
-#define VSCP_TYPE_MEASUREMENT64_ELECTRIC_CURRENT        5
+#define VSCP_TYPE_MEASUREMENT64_ELECTRIC_CURRENT             5
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of a temperature.
  */
-#define VSCP_TYPE_MEASUREMENT64_TEMPERATURE             6
+#define VSCP_TYPE_MEASUREMENT64_TEMPERATURE                  6
 
 /**
  * Default unit: Mole.
  * This is a measurement of an amount of a substance.
  */
-#define VSCP_TYPE_MEASUREMENT64_AMOUNT_OF_SUBSTANCE     7
+#define VSCP_TYPE_MEASUREMENT64_AMOUNT_OF_SUBSTANCE          7
 
 /**
  * Default unit: Candela.
  * This is a measurement of luminous intensity.
  */
-#define VSCP_TYPE_MEASUREMENT64_INTENSITY_OF_LIGHT      8
+#define VSCP_TYPE_MEASUREMENT64_INTENSITY_OF_LIGHT           8
 
 /**
  * Default unit: Hertz.
  * This is a measurement of regular events during a second.
  */
-#define VSCP_TYPE_MEASUREMENT64_FREQUENCY               9
+#define VSCP_TYPE_MEASUREMENT64_FREQUENCY                    9
 
 /**
  * Default unit: becquerel.
  * Optional unit: curie (1)
  * This is a measurement of rates of things, which happen randomly, or are unpredictable.
  */
-#define VSCP_TYPE_MEASUREMENT64_RADIOACTIVITY           10
+#define VSCP_TYPE_MEASUREMENT64_RADIOACTIVITY                10
 
 /**
  * Default unit: newton.
  * This is a measurement of force.
  */
-#define VSCP_TYPE_MEASUREMENT64_FORCE                   11
+#define VSCP_TYPE_MEASUREMENT64_FORCE                        11
 
 /**
  * Default unit: pascal.
  * Opt. unit: bar (1), psi (2)
  * This is a measurement of pressure.
  */
-#define VSCP_TYPE_MEASUREMENT64_PRESSURE                12
+#define VSCP_TYPE_MEASUREMENT64_PRESSURE                     12
 
 /**
  * Default unit: Joule.
  * Optional unit: KWh (1)
  * This is a measurement of energy.
  */
-#define VSCP_TYPE_MEASUREMENT64_ENERGY                  13
+#define VSCP_TYPE_MEASUREMENT64_ENERGY                       13
 
 /**
  * Default unit: watt.
  * Optional unit: Horse power (1).
  * This is a measurement of power.
  */
-#define VSCP_TYPE_MEASUREMENT64_POWER                   14
+#define VSCP_TYPE_MEASUREMENT64_POWER                        14
 
 /**
  * Default unit: coulomb.
  * This is a measurement electrical charge.
  */
-#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_CHARGE       15
+#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_CHARGE            15
 
 /**
  * Default unit: volt.
  * This is a measurement of electrical potential.
  */
-#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_POTENTIAL    16
+#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_POTENTIAL         16
 
 /**
  * Default unit: farad (F).
  * This is a measurement of electric capacitance.
  */
-#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_CAPACITANCE  17
+#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_CAPACITANCE       17
 
 /**
  * Default unit: ohm (Ω).
  * This is a measurement of resistance.
  */
-#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_RESISTANCE   18
+#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_RESISTANCE        18
 
 /**
  * Default unit: siemens.
  * This is a measurement of electrical conductance.
  */
-#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_CONDUCTANCE  19
+#define VSCP_TYPE_MEASUREMENT64_ELECTRICAL_CONDUCTANCE       19
 
 /**
  * Default unit: amperes per meter (H).
  * Optional units: teslas (B) (1)
  * This is a measurement of magnetic field strength.
  */
-#define VSCP_TYPE_MEASUREMENT64_MAGNETIC_FIELD_STRENGTH 20
+#define VSCP_TYPE_MEASUREMENT64_MAGNETIC_FIELD_STRENGTH      20
 
 /**
  * Default unit: weber (Wb).
  * This is a measurement of magnetic flux.
  */
-#define VSCP_TYPE_MEASUREMENT64_MAGNETIC_FLUX           21
+#define VSCP_TYPE_MEASUREMENT64_MAGNETIC_FLUX                21
 
 /**
  * Default unit: tesla (B).
+ * Optional units: Gauss (1)
  * This is a measurement of flux density or field strength for magnetic fields (also called the
  * magnetic induction).
  */
-#define VSCP_TYPE_MEASUREMENT64_MAGNETIC_FLUX_DENSITY   22
+#define VSCP_TYPE_MEASUREMENT64_MAGNETIC_FLUX_DENSITY        22
 
 /**
  * Default unit: henry (H).
  * This is a measurement of inductance.
  */
-#define VSCP_TYPE_MEASUREMENT64_INDUCTANCE              23
+#define VSCP_TYPE_MEASUREMENT64_INDUCTANCE                   23
 
 /**
  * Default unit: Lumen (lm= cd * sr)
  * This is a measurement of luminous Flux.
  */
-#define VSCP_TYPE_MEASUREMENT64_FLUX_OF_LIGHT           24
+#define VSCP_TYPE_MEASUREMENT64_FLUX_OF_LIGHT                24
 
 /**
  * Default unit: lux (lx) ( lx = lm / m² )
  * This is used to express both Illuminance (incidence of light) and Luminous Emittance (emission of
  * light).
  */
-#define VSCP_TYPE_MEASUREMENT64_ILLUMINANCE             25
+#define VSCP_TYPE_MEASUREMENT64_ILLUMINANCE                  25
 
 /**
  * Default unit: gray (Gy).
- * Opt unit: sievert (Sv) (1).
  * This is a measurement of a radiation dose (Absorbed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE          26
+#define VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_ABSORBED      26
 
 /**
- * Default unit: katal (z).
+ * Default unit: katal (kat).
  * This is a measurement of catalytic activity used in biochemistry.
  */
-#define VSCP_TYPE_MEASUREMENT64_CATALYTIC_ACITIVITY     27
+#define VSCP_TYPE_MEASUREMENT64_CATALYTIC_ACITIVITY          27
 
 /**
  * Default unit: cubic meter (m³)
@@ -249,13 +249,13 @@ extern "C"
  * where unit 4 is only available for Level II measurement events where units can hold this value.
  * This is a measurement of volume.
  */
-#define VSCP_TYPE_MEASUREMENT64_VOLUME                  28
+#define VSCP_TYPE_MEASUREMENT64_VOLUME                       28
 
 /**
  * Default unit: W/m2, watt per square meter.
  * This is a measurement of sound intensity (acoustic intensity).
  */
-#define VSCP_TYPE_MEASUREMENT64_SOUND_INTENSITY         29
+#define VSCP_TYPE_MEASUREMENT64_SOUND_INTENSITY              29
 
 /**
  * Default unit: radian (rad) (Plane angles).
@@ -264,162 +264,163 @@ extern "C"
  * Opt Unit: arcseconds (3).
  * This is a measurement of an angle.
  */
-#define VSCP_TYPE_MEASUREMENT64_ANGLE                   30
+#define VSCP_TYPE_MEASUREMENT64_ANGLE                        30
 
 /**
  * Default unit: Longitude.
  * Opt. unit: Latitude.
- * This is a measurement of a position as of WGS 84. Normally given as a floating point value. See
- * ./class1.gps.md for a better candidate to use for position data.
+ * This is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point
+ * value. See ./class1.gps.md for a better candidate to use for position data.
  */
-#define VSCP_TYPE_MEASUREMENT64_POSITION                31
+#define VSCP_TYPE_MEASUREMENT64_POSITION                     31
 
 /**
  * Default unit: Meters per second.
  * Optional unit: Kilometers per hour (1) Miles per hour (2)
  * This is a measurement of a speed.
  */
-#define VSCP_TYPE_MEASUREMENT64_SPEED                   32
+#define VSCP_TYPE_MEASUREMENT64_SPEED                        32
 
 /**
  * Default unit: Meters per second/second (m/s2).
  * This is a measurement of acceleration.
  */
-#define VSCP_TYPE_MEASUREMENT64_ACCELERATION            33
+#define VSCP_TYPE_MEASUREMENT64_ACCELERATION                 33
 
 /**
  * Default unit: N/m.
  * This is a measurement of tension.
  */
-#define VSCP_TYPE_MEASUREMENT64_TENSION                 34
+#define VSCP_TYPE_MEASUREMENT64_TENSION                      34
 
 /**
  * Default unit: Relative percentage 0-100%.
  * This is a measurement of relative moistness (Humidity).
  */
-#define VSCP_TYPE_MEASUREMENT64_HUMIDITY                35
+#define VSCP_TYPE_MEASUREMENT64_HUMIDITY                     35
 
 /**
  * Default unit: Cubic meters/second.
  * Opt Unit: Liters/Second.
  * This is a measurement of flow.
  */
-#define VSCP_TYPE_MEASUREMENT64_FLOW                    36
+#define VSCP_TYPE_MEASUREMENT64_FLOW                         36
 
 /**
  * Default unit: Thermal ohm K/W.
  * This is a measurement of thermal resistance.
  */
-#define VSCP_TYPE_MEASUREMENT64_THERMAL_RESISTANCE      37
+#define VSCP_TYPE_MEASUREMENT64_THERMAL_RESISTANCE           37
 
 /**
  * Default unit: dioptre (dpt) m-1.
  * This is a measurement of refractive (optical) power.
  */
-#define VSCP_TYPE_MEASUREMENT64_REFRACTIVE_POWER        38
+#define VSCP_TYPE_MEASUREMENT64_REFRACTIVE_POWER             38
 
 /**
- * Default unit: poiseuille (Pl)
+ * Default unit: pascal second
+ * Optional units: poiseuille (Pl) = 1, poise (P) = 2
  * This is a measurement of dynamic viscosity.
  */
-#define VSCP_TYPE_MEASUREMENT64_DYNAMIC_VISCOSITY       39
+#define VSCP_TYPE_MEASUREMENT64_DYNAMIC_VISCOSITY            39
 
 /**
  * Default unit: rayl (Pa·s/m)
  * This is a measurement of sound impedance.
  */
-#define VSCP_TYPE_MEASUREMENT64_SOUND_IMPEDANCE         40
+#define VSCP_TYPE_MEASUREMENT64_SOUND_IMPEDANCE              40
 
 /**
  * Default unit: Acoustic ohm Pa · s/ m³.
  * This is a measurement of sound resistance.
  */
-#define VSCP_TYPE_MEASUREMENT64_SOUND_RESISTANCE        41
+#define VSCP_TYPE_MEASUREMENT64_SOUND_RESISTANCE             41
 
 /**
  * Default unit: daraf (f-1).
  * This is a measurement of electric elasticity.
  */
-#define VSCP_TYPE_MEASUREMENT64_ELECTRIC_ELASTANCE      42
+#define VSCP_TYPE_MEASUREMENT64_ELECTRIC_ELASTANCE           42
 
 /**
  * Default unit: talbot ( tb = lm * s)
  * This is a measurement of luminous energy.
  */
-#define VSCP_TYPE_MEASUREMENT64_LUMINOUS_ENERGY         43
+#define VSCP_TYPE_MEASUREMENT64_LUMINOUS_ENERGY              43
 
 /**
  * Default unit: cd / m²) (non SI unit = nit)
  * This is a measurement of luminance.
  */
-#define VSCP_TYPE_MEASUREMENT64_LUMINANCE               44
+#define VSCP_TYPE_MEASUREMENT64_LUMINANCE                    44
 
 /**
- * Default unit: molal (mol/kg).
- * This is a measurement of chemical concentration.
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mol/ppm/percent concentration.
  */
-#define VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION  45
+#define VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION_MOLAR 45
 
 /**
- * Reserved (previously was doublet of Type= 26, don't use any longer!)
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mass concentration.
  */
-#define VSCP_TYPE_MEASUREMENT64_RESERVED46              46
+#define VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION_MASS  46
 
 /**
- * Default unit: sievert (J/Kg).
- * This is a measurement of dose equivalent.
+ * Reserved.
  */
-#define VSCP_TYPE_MEASUREMENT64_DOSE_EQVIVALENT         47
+#define VSCP_TYPE_MEASUREMENT64_RESERVED47                   47
 
 /**
  * Reserved (was doublet of Type= 24, do not use any longer!)
  */
-#define VSCP_TYPE_MEASUREMENT64_RESERVED48              48
+#define VSCP_TYPE_MEASUREMENT64_RESERVED48                   48
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of the Dew Point.
  */
-#define VSCP_TYPE_MEASUREMENT64_DEWPOINT                49
+#define VSCP_TYPE_MEASUREMENT64_DEWPOINT                     49
 
 /**
  * Default unit: Relative value.
  * This is a relative value for a level measurement without a unit. It is just relative to the min/max
  * value for the selected data representation, typically percentage or per mille or similar.
  */
-#define VSCP_TYPE_MEASUREMENT64_RELATIVE_LEVEL          50
+#define VSCP_TYPE_MEASUREMENT64_RELATIVE_LEVEL               50
 
 /**
  * Default unit: Meter.
  * Opt. unit: Feet(1), inches (2)
  * Altitude in meters.
  */
-#define VSCP_TYPE_MEASUREMENT64_ALTITUDE                51
+#define VSCP_TYPE_MEASUREMENT64_ALTITUDE                     51
 
 /**
  * Default unit: square meter (m²)
  * Area in square meter.
  */
-#define VSCP_TYPE_MEASUREMENT64_AREA                    52
+#define VSCP_TYPE_MEASUREMENT64_AREA                         52
 
 /**
  * Default unit: watt per steradian ( W / sr )
  * Radiated power per room angle.
  */
-#define VSCP_TYPE_MEASUREMENT64_RADIANT_INTENSITY       53
+#define VSCP_TYPE_MEASUREMENT64_RADIANT_INTENSITY            53
 
 /**
  * Default unit: watt per steradian per square metre ( W / (sr * m²) )
  * This is the radiant flux emitted, reflected, transmitted or received by a surface.
  */
-#define VSCP_TYPE_MEASUREMENT64_RADIANCE                54
+#define VSCP_TYPE_MEASUREMENT64_RADIANCE                     54
 
 /**
  * Default unit: watt per square metre ( W / m² )
  * Power emitted from or striking onto a surface or area.
  */
-#define VSCP_TYPE_MEASUREMENT64_IRRADIANCE              55
+#define VSCP_TYPE_MEASUREMENT64_IRRADIANCE                   55
 
 /**
  * Default unit: watt per steradian per square metre per nm (W·sr-1·m-2·nm-1)
@@ -427,46 +428,46 @@ extern "C"
  * hertz (W·sr-1·m-3) (2)
  * Radiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREMENT64_SPECTRAL_RADIANCE       56
+#define VSCP_TYPE_MEASUREMENT64_SPECTRAL_RADIANCE            56
 
 /**
  * Default unit: watt per square metre per nm (W·m-2·nm-1)
  * Opt. unit: watt per metre3 (W·m-3) (1), watt per square metre per hertz (W·m-2·Hz-1) (2)
  * Irradiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREMENT64_SPECTRAL_IRRADIANCE     57
+#define VSCP_TYPE_MEASUREMENT64_SPECTRAL_IRRADIANCE          57
 
 /**
  * Default unit: pascal (Pa)
  * This is a measurement of sound pressure (acoustic pressure).
  */
-#define VSCP_TYPE_MEASUREMENT64_SOUND_PRESSURE          58
+#define VSCP_TYPE_MEASUREMENT64_SOUND_PRESSURE               58
 
 /**
  * Default unit: pascal (Pa)
  * Sound energy density or sound density is the sound energy per unit volume.
  */
-#define VSCP_TYPE_MEASUREMENT64_SOUND_DENSITY           59
+#define VSCP_TYPE_MEASUREMENT64_SOUND_DENSITY                59
 
 /**
  * Default unit: decibel (dB)
  * Sound level expressed in decibel. This event is supplied for convenience.
  */
-#define VSCP_TYPE_MEASUREMENT64_SOUND_LEVEL             60
+#define VSCP_TYPE_MEASUREMENT64_SOUND_LEVEL                  60
 
 /**
  * Default unit: sievert (Sv).
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_EQ       61
+#define VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_EQ            61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).
  * Optional unit: Röntgen/R (1)
  * This is a measurement of a radiation dose (Exposed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_EXPOSURE 62
+#define VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_EXPOSURE      62
 
 /**
  * Default unit: cos of phase angle.
@@ -474,7 +475,7 @@ extern "C"
  * usually expressed as a percentage - and the lower the percentage, the less efficient power usage
  * is.
  */
-#define VSCP_TYPE_MEASUREMENT64_POWER_FACTOR            63
+#define VSCP_TYPE_MEASUREMENT64_POWER_FACTOR                 63
 
 /**
  * Default unit: VAr
@@ -482,14 +483,14 @@ extern "C"
  * measurement of reactive power. Reactive power exists in AC circuit when the current and voltage are
  * not in phase.
  */
-#define VSCP_TYPE_MEASUREMENT64_REACTIVE_POWER          64
+#define VSCP_TYPE_MEASUREMENT64_REACTIVE_POWER               64
 
 /**
  * Default unit: kVArh
  * Reactive energy is the electrical energy produced, flowing or supplied by an electric circuit
  * during a time interval, measured in units of kVArh or standard multiples thereof.
  */
-#define VSCP_TYPE_MEASUREMENT64_REACTIVE_ENERGY         65
+#define VSCP_TYPE_MEASUREMENT64_REACTIVE_ENERGY              65
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_type_measurement64.h
+++ b/src/vscp_type_measurement64.h
@@ -149,14 +149,14 @@ extern "C"
 
 /**
  * Default unit: Joule.
- * Optional unit: KWh (1)
+ * Optional unit: kWh (1), Wh (2), eV (electron volt) (3)
  * This is a measurement of energy.
  */
 #define VSCP_TYPE_MEASUREMENT64_ENERGY                       13
 
 /**
  * Default unit: watt.
- * Optional unit: Horse power (1).
+ * Optional unit: Horse power Metric (1), Horse power Imperial (2).
  * This is a measurement of power.
  */
 #define VSCP_TYPE_MEASUREMENT64_POWER                        14
@@ -193,7 +193,7 @@ extern "C"
 
 /**
  * Default unit: amperes per meter (H).
- * Optional units: teslas (B) (1)
+ * Optional units: Oersted (Oe) (1)
  * This is a measurement of magnetic field strength.
  */
 #define VSCP_TYPE_MEASUREMENT64_MAGNETIC_FIELD_STRENGTH      20
@@ -245,8 +245,9 @@ extern "C"
 
 /**
  * Default unit: cubic meter (m³)
- * Opt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4)
- * where unit 4 is only available for Level II measurement events where units can hold this value.
+ * Opt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4),
+ * millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can
+ * hold this value.
  * This is a measurement of volume.
  */
 #define VSCP_TYPE_MEASUREMENT64_VOLUME                       28
@@ -276,13 +277,13 @@ extern "C"
 
 /**
  * Default unit: Meters per second.
- * Optional unit: Kilometers per hour (1) Miles per hour (2)
+ * Optional unit: Kilometers per hour (1), Miles per hour (2)
  * This is a measurement of a speed.
  */
 #define VSCP_TYPE_MEASUREMENT64_SPEED                        32
 
 /**
- * Default unit: Meters per second/second (m/s2).
+ * Default unit: Meter per second squared (m/s²).
  * This is a measurement of acceleration.
  */
 #define VSCP_TYPE_MEASUREMENT64_ACCELERATION                 33
@@ -338,7 +339,7 @@ extern "C"
 #define VSCP_TYPE_MEASUREMENT64_SOUND_RESISTANCE             41
 
 /**
- * Default unit: daraf (f-1).
+ * Default unit: daraf (F-1).
  * This is a measurement of electric elasticity.
  */
 #define VSCP_TYPE_MEASUREMENT64_ELECTRIC_ELASTANCE           42
@@ -400,6 +401,7 @@ extern "C"
 
 /**
  * Default unit: square meter (m²)
+ * Opt. unit: are (1), hectare (2), square kilometer (km²)
  * Area in square meter.
  */
 #define VSCP_TYPE_MEASUREMENT64_AREA                         52

--- a/src/vscp_type_measurement64.h
+++ b/src/vscp_type_measurement64.h
@@ -460,7 +460,7 @@ extern "C"
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_EQ            61
+#define VSCP_TYPE_MEASUREMENT64_DOSE_EQUIVALENT              61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).

--- a/src/vscp_type_measurezone.h
+++ b/src/vscp_type_measurezone.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_measurezone.h
+++ b/src/vscp_type_measurezone.h
@@ -151,14 +151,14 @@ extern "C"
 
 /**
  * Default unit: Joule.
- * Optional unit: KWh (1)
+ * Optional unit: kWh (1), Wh (2), eV (electron volt) (3)
  * This is a measurement of energy.
  */
 #define VSCP_TYPE_MEASUREZONE_ENERGY                       13
 
 /**
  * Default unit: watt.
- * Optional unit: Horse power (1).
+ * Optional unit: Horse power Metric (1), Horse power Imperial (2).
  * This is a measurement of power.
  */
 #define VSCP_TYPE_MEASUREZONE_POWER                        14
@@ -195,7 +195,7 @@ extern "C"
 
 /**
  * Default unit: amperes per meter (H).
- * Optional units: teslas (B) (1)
+ * Optional units: Oersted (Oe) (1)
  * This is a measurement of magnetic field strength.
  */
 #define VSCP_TYPE_MEASUREZONE_MAGNETIC_FIELD_STRENGTH      20
@@ -247,8 +247,9 @@ extern "C"
 
 /**
  * Default unit: cubic meter (m³)
- * Opt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4)
- * where unit 4 is only available for Level II measurement events where units can hold this value.
+ * Opt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4),
+ * millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can
+ * hold this value.
  * This is a measurement of volume.
  */
 #define VSCP_TYPE_MEASUREZONE_VOLUME                       28
@@ -278,13 +279,13 @@ extern "C"
 
 /**
  * Default unit: Meters per second.
- * Optional unit: Kilometers per hour (1) Miles per hour (2)
+ * Optional unit: Kilometers per hour (1), Miles per hour (2)
  * This is a measurement of a speed.
  */
 #define VSCP_TYPE_MEASUREZONE_SPEED                        32
 
 /**
- * Default unit: Meters per second/second (m/s2).
+ * Default unit: Meter per second squared (m/s²).
  * This is a measurement of acceleration.
  */
 #define VSCP_TYPE_MEASUREZONE_ACCELERATION                 33
@@ -340,7 +341,7 @@ extern "C"
 #define VSCP_TYPE_MEASUREZONE_SOUND_RESISTANCE             41
 
 /**
- * Default unit: daraf (f-1).
+ * Default unit: daraf (F-1).
  * This is a measurement of electric elasticity.
  */
 #define VSCP_TYPE_MEASUREZONE_ELECTRIC_ELASTANCE           42
@@ -402,6 +403,7 @@ extern "C"
 
 /**
  * Default unit: square meter (m²)
+ * Opt. unit: are (1), hectare (2), square kilometer (km²)
  * Area in square meter.
  */
 #define VSCP_TYPE_MEASUREZONE_AREA                         52

--- a/src/vscp_type_measurezone.h
+++ b/src/vscp_type_measurezone.h
@@ -462,7 +462,7 @@ extern "C"
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_EQ            61
+#define VSCP_TYPE_MEASUREZONE_DOSE_EQUIVALENT              61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).

--- a/src/vscp_type_measurezone.h
+++ b/src/vscp_type_measurezone.h
@@ -71,179 +71,179 @@ extern "C"
 /**
  * General Event.
  */
-#define VSCP_TYPE_MEASUREZONE_GENERAL                 0
+#define VSCP_TYPE_MEASUREZONE_GENERAL                      0
 
 /**
  * This is a discrete value typical for a count. There is no unit for this measurement just a discrete
  * value.
  */
-#define VSCP_TYPE_MEASUREZONE_COUNT                   1
+#define VSCP_TYPE_MEASUREZONE_COUNT                        1
 
 /**
  * Default unit: Meter.
  * This is a measurement of a length or a distance.
  */
-#define VSCP_TYPE_MEASUREZONE_LENGTH                  2
+#define VSCP_TYPE_MEASUREZONE_LENGTH                       2
 
 /**
  * Default unit: Kilogram.
  * This is a measurement of a mass.
  */
-#define VSCP_TYPE_MEASUREZONE_MASS                    3
+#define VSCP_TYPE_MEASUREZONE_MASS                         3
 
 /**
  * A time measurement.
  * Default unit: Seconds.
  * Opt. unit: (1) Milliseconds. Absolute: (2) y-y-m-d-h-m-s (binary). String: (3) "HHMMSS".
  */
-#define VSCP_TYPE_MEASUREZONE_TIME                    4
+#define VSCP_TYPE_MEASUREZONE_TIME                         4
 
 /**
  * Default unit: Ampere.
  * This is a measurement of an electric current.
  */
-#define VSCP_TYPE_MEASUREZONE_ELECTRIC_CURRENT        5
+#define VSCP_TYPE_MEASUREZONE_ELECTRIC_CURRENT             5
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of a temperature.
  */
-#define VSCP_TYPE_MEASUREZONE_TEMPERATURE             6
+#define VSCP_TYPE_MEASUREZONE_TEMPERATURE                  6
 
 /**
  * Default unit: Mole.
  * This is a measurement of an amount of a substance.
  */
-#define VSCP_TYPE_MEASUREZONE_AMOUNT_OF_SUBSTANCE     7
+#define VSCP_TYPE_MEASUREZONE_AMOUNT_OF_SUBSTANCE          7
 
 /**
  * Default unit: Candela.
  * This is a measurement of luminous intensity.
  */
-#define VSCP_TYPE_MEASUREZONE_INTENSITY_OF_LIGHT      8
+#define VSCP_TYPE_MEASUREZONE_INTENSITY_OF_LIGHT           8
 
 /**
  * Default unit: Hertz.
  * This is a measurement of regular events during a second.
  */
-#define VSCP_TYPE_MEASUREZONE_FREQUENCY               9
+#define VSCP_TYPE_MEASUREZONE_FREQUENCY                    9
 
 /**
  * Default unit: becquerel.
  * Optional unit: curie (1)
  * This is a measurement of rates of things, which happen randomly, or are unpredictable.
  */
-#define VSCP_TYPE_MEASUREZONE_RADIOACTIVITY           10
+#define VSCP_TYPE_MEASUREZONE_RADIOACTIVITY                10
 
 /**
  * Default unit: newton.
  * This is a measurement of force.
  */
-#define VSCP_TYPE_MEASUREZONE_FORCE                   11
+#define VSCP_TYPE_MEASUREZONE_FORCE                        11
 
 /**
  * Default unit: pascal.
  * Opt. unit: bar (1), psi (2)
  * This is a measurement of pressure.
  */
-#define VSCP_TYPE_MEASUREZONE_PRESSURE                12
+#define VSCP_TYPE_MEASUREZONE_PRESSURE                     12
 
 /**
  * Default unit: Joule.
  * Optional unit: KWh (1)
  * This is a measurement of energy.
  */
-#define VSCP_TYPE_MEASUREZONE_ENERGY                  13
+#define VSCP_TYPE_MEASUREZONE_ENERGY                       13
 
 /**
  * Default unit: watt.
  * Optional unit: Horse power (1).
  * This is a measurement of power.
  */
-#define VSCP_TYPE_MEASUREZONE_POWER                   14
+#define VSCP_TYPE_MEASUREZONE_POWER                        14
 
 /**
  * Default unit: coulomb.
  * This is a measurement electrical charge.
  */
-#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_CHARGE       15
+#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_CHARGE            15
 
 /**
  * Default unit: volt.
  * This is a measurement of electrical potential.
  */
-#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_POTENTIAL    16
+#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_POTENTIAL         16
 
 /**
  * Default unit: farad (F).
  * This is a measurement of electric capacitance.
  */
-#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_CAPACITANCE  17
+#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_CAPACITANCE       17
 
 /**
  * Default unit: ohm (Ω).
  * This is a measurement of resistance.
  */
-#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_RESISTANCE   18
+#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_RESISTANCE        18
 
 /**
  * Default unit: siemens.
  * This is a measurement of electrical conductance.
  */
-#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_CONDUCTANCE  19
+#define VSCP_TYPE_MEASUREZONE_ELECTRICAL_CONDUCTANCE       19
 
 /**
  * Default unit: amperes per meter (H).
  * Optional units: teslas (B) (1)
  * This is a measurement of magnetic field strength.
  */
-#define VSCP_TYPE_MEASUREZONE_MAGNETIC_FIELD_STRENGTH 20
+#define VSCP_TYPE_MEASUREZONE_MAGNETIC_FIELD_STRENGTH      20
 
 /**
  * Default unit: weber (Wb).
  * This is a measurement of magnetic flux.
  */
-#define VSCP_TYPE_MEASUREZONE_MAGNETIC_FLUX           21
+#define VSCP_TYPE_MEASUREZONE_MAGNETIC_FLUX                21
 
 /**
  * Default unit: tesla (B).
+ * Optional units: Gauss (1)
  * This is a measurement of flux density or field strength for magnetic fields (also called the
  * magnetic induction).
  */
-#define VSCP_TYPE_MEASUREZONE_MAGNETIC_FLUX_DENSITY   22
+#define VSCP_TYPE_MEASUREZONE_MAGNETIC_FLUX_DENSITY        22
 
 /**
  * Default unit: henry (H).
  * This is a measurement of inductance.
  */
-#define VSCP_TYPE_MEASUREZONE_INDUCTANCE              23
+#define VSCP_TYPE_MEASUREZONE_INDUCTANCE                   23
 
 /**
  * Default unit: Lumen (lm= cd * sr)
  * This is a measurement of luminous Flux.
  */
-#define VSCP_TYPE_MEASUREZONE_FLUX_OF_LIGHT           24
+#define VSCP_TYPE_MEASUREZONE_FLUX_OF_LIGHT                24
 
 /**
  * Default unit: lux (lx) ( lx = lm / m² )
  * This is used to express both Illuminance (incidence of light) and Luminous Emittance (emission of
  * light).
  */
-#define VSCP_TYPE_MEASUREZONE_ILLUMINANCE             25
+#define VSCP_TYPE_MEASUREZONE_ILLUMINANCE                  25
 
 /**
  * Default unit: gray (Gy).
- * Opt unit: sievert (Sv) (1).
  * This is a measurement of a radiation dose (Absorbed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREZONE_RADIATION_DOSE          26
+#define VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_ABSORBED      26
 
 /**
- * Default unit: katal (z).
+ * Default unit: katal (kat).
  * This is a measurement of catalytic activity used in biochemistry.
  */
-#define VSCP_TYPE_MEASUREZONE_CATALYTIC_ACITIVITY     27
+#define VSCP_TYPE_MEASUREZONE_CATALYTIC_ACITIVITY          27
 
 /**
  * Default unit: cubic meter (m³)
@@ -251,13 +251,13 @@ extern "C"
  * where unit 4 is only available for Level II measurement events where units can hold this value.
  * This is a measurement of volume.
  */
-#define VSCP_TYPE_MEASUREZONE_VOLUME                  28
+#define VSCP_TYPE_MEASUREZONE_VOLUME                       28
 
 /**
  * Default unit: W/m2, watt per square meter.
  * This is a measurement of sound intensity (acoustic intensity).
  */
-#define VSCP_TYPE_MEASUREZONE_SOUND_INTENSITY         29
+#define VSCP_TYPE_MEASUREZONE_SOUND_INTENSITY              29
 
 /**
  * Default unit: radian (rad) (Plane angles).
@@ -266,162 +266,163 @@ extern "C"
  * Opt Unit: arcseconds (3).
  * This is a measurement of an angle.
  */
-#define VSCP_TYPE_MEASUREZONE_ANGLE                   30
+#define VSCP_TYPE_MEASUREZONE_ANGLE                        30
 
 /**
  * Default unit: Longitude.
  * Opt. unit: Latitude.
- * This is a measurement of a position as of WGS 84. Normally given as a floating point value. See
- * ./class1.gps.md for a better candidate to use for position data.
+ * This is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point
+ * value. See ./class1.gps.md for a better candidate to use for position data.
  */
-#define VSCP_TYPE_MEASUREZONE_POSITION                31
+#define VSCP_TYPE_MEASUREZONE_POSITION                     31
 
 /**
  * Default unit: Meters per second.
  * Optional unit: Kilometers per hour (1) Miles per hour (2)
  * This is a measurement of a speed.
  */
-#define VSCP_TYPE_MEASUREZONE_SPEED                   32
+#define VSCP_TYPE_MEASUREZONE_SPEED                        32
 
 /**
  * Default unit: Meters per second/second (m/s2).
  * This is a measurement of acceleration.
  */
-#define VSCP_TYPE_MEASUREZONE_ACCELERATION            33
+#define VSCP_TYPE_MEASUREZONE_ACCELERATION                 33
 
 /**
  * Default unit: N/m.
  * This is a measurement of tension.
  */
-#define VSCP_TYPE_MEASUREZONE_TENSION                 34
+#define VSCP_TYPE_MEASUREZONE_TENSION                      34
 
 /**
  * Default unit: Relative percentage 0-100%.
  * This is a measurement of relative moistness (Humidity).
  */
-#define VSCP_TYPE_MEASUREZONE_HUMIDITY                35
+#define VSCP_TYPE_MEASUREZONE_HUMIDITY                     35
 
 /**
  * Default unit: Cubic meters/second.
  * Opt Unit: Liters/Second.
  * This is a measurement of flow.
  */
-#define VSCP_TYPE_MEASUREZONE_FLOW                    36
+#define VSCP_TYPE_MEASUREZONE_FLOW                         36
 
 /**
  * Default unit: Thermal ohm K/W.
  * This is a measurement of thermal resistance.
  */
-#define VSCP_TYPE_MEASUREZONE_THERMAL_RESISTANCE      37
+#define VSCP_TYPE_MEASUREZONE_THERMAL_RESISTANCE           37
 
 /**
  * Default unit: dioptre (dpt) m-1.
  * This is a measurement of refractive (optical) power.
  */
-#define VSCP_TYPE_MEASUREZONE_REFRACTIVE_POWER        38
+#define VSCP_TYPE_MEASUREZONE_REFRACTIVE_POWER             38
 
 /**
- * Default unit: poiseuille (Pl)
+ * Default unit: pascal second
+ * Optional units: poiseuille (Pl) = 1, poise (P) = 2
  * This is a measurement of dynamic viscosity.
  */
-#define VSCP_TYPE_MEASUREZONE_DYNAMIC_VISCOSITY       39
+#define VSCP_TYPE_MEASUREZONE_DYNAMIC_VISCOSITY            39
 
 /**
  * Default unit: rayl (Pa·s/m)
  * This is a measurement of sound impedance.
  */
-#define VSCP_TYPE_MEASUREZONE_SOUND_IMPEDANCE         40
+#define VSCP_TYPE_MEASUREZONE_SOUND_IMPEDANCE              40
 
 /**
  * Default unit: Acoustic ohm Pa · s/ m³.
  * This is a measurement of sound resistance.
  */
-#define VSCP_TYPE_MEASUREZONE_SOUND_RESISTANCE        41
+#define VSCP_TYPE_MEASUREZONE_SOUND_RESISTANCE             41
 
 /**
  * Default unit: daraf (f-1).
  * This is a measurement of electric elasticity.
  */
-#define VSCP_TYPE_MEASUREZONE_ELECTRIC_ELASTANCE      42
+#define VSCP_TYPE_MEASUREZONE_ELECTRIC_ELASTANCE           42
 
 /**
  * Default unit: talbot ( tb = lm * s)
  * This is a measurement of luminous energy.
  */
-#define VSCP_TYPE_MEASUREZONE_LUMINOUS_ENERGY         43
+#define VSCP_TYPE_MEASUREZONE_LUMINOUS_ENERGY              43
 
 /**
  * Default unit: cd / m²) (non SI unit = nit)
  * This is a measurement of luminance.
  */
-#define VSCP_TYPE_MEASUREZONE_LUMINANCE               44
+#define VSCP_TYPE_MEASUREZONE_LUMINANCE                    44
 
 /**
- * Default unit: molal (mol/kg).
- * This is a measurement of chemical concentration.
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mol/ppm/percent concentration.
  */
-#define VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION  45
+#define VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION_MOLAR 45
 
 /**
- * Reserved (previously was doublet of Type= 26, don't use any longer!)
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mass concentration.
  */
-#define VSCP_TYPE_MEASUREZONE_RESERVED46              46
+#define VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION_MASS  46
 
 /**
- * Default unit: sievert (J/Kg).
- * This is a measurement of dose equivalent.
+ * Reserved.
  */
-#define VSCP_TYPE_MEASUREZONE_DOSE_EQVIVALENT         47
+#define VSCP_TYPE_MEASUREZONE_RESERVED47                   47
 
 /**
  * Reserved (was doublet of Type= 24, do not use any longer!)
  */
-#define VSCP_TYPE_MEASUREZONE_RESERVED48              48
+#define VSCP_TYPE_MEASUREZONE_RESERVED48                   48
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of the Dew Point.
  */
-#define VSCP_TYPE_MEASUREZONE_DEWPOINT                49
+#define VSCP_TYPE_MEASUREZONE_DEWPOINT                     49
 
 /**
  * Default unit: Relative value.
  * This is a relative value for a level measurement without a unit. It is just relative to the min/max
  * value for the selected data representation, typically percentage or per mille or similar.
  */
-#define VSCP_TYPE_MEASUREZONE_RELATIVE_LEVEL          50
+#define VSCP_TYPE_MEASUREZONE_RELATIVE_LEVEL               50
 
 /**
  * Default unit: Meter.
  * Opt. unit: Feet(1), inches (2)
  * Altitude in meters.
  */
-#define VSCP_TYPE_MEASUREZONE_ALTITUDE                51
+#define VSCP_TYPE_MEASUREZONE_ALTITUDE                     51
 
 /**
  * Default unit: square meter (m²)
  * Area in square meter.
  */
-#define VSCP_TYPE_MEASUREZONE_AREA                    52
+#define VSCP_TYPE_MEASUREZONE_AREA                         52
 
 /**
  * Default unit: watt per steradian ( W / sr )
  * Radiated power per room angle.
  */
-#define VSCP_TYPE_MEASUREZONE_RADIANT_INTENSITY       53
+#define VSCP_TYPE_MEASUREZONE_RADIANT_INTENSITY            53
 
 /**
  * Default unit: watt per steradian per square metre ( W / (sr * m²) )
  * This is the radiant flux emitted, reflected, transmitted or received by a surface.
  */
-#define VSCP_TYPE_MEASUREZONE_RADIANCE                54
+#define VSCP_TYPE_MEASUREZONE_RADIANCE                     54
 
 /**
  * Default unit: watt per square metre ( W / m² )
  * Power emitted from or striking onto a surface or area.
  */
-#define VSCP_TYPE_MEASUREZONE_IRRADIANCE              55
+#define VSCP_TYPE_MEASUREZONE_IRRADIANCE                   55
 
 /**
  * Default unit: watt per steradian per square metre per nm (W·sr-1·m-2·nm-1)
@@ -429,46 +430,46 @@ extern "C"
  * hertz (W·sr-1·m-3) (2)
  * Radiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREZONE_SPECTRAL_RADIANCE       56
+#define VSCP_TYPE_MEASUREZONE_SPECTRAL_RADIANCE            56
 
 /**
  * Default unit: watt per square metre per nm (W·m-2·nm-1)
  * Opt. unit: watt per metre3 (W·m-3) (1), watt per square metre per hertz (W·m-2·Hz-1) (2)
  * Irradiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_MEASUREZONE_SPECTRAL_IRRADIANCE     57
+#define VSCP_TYPE_MEASUREZONE_SPECTRAL_IRRADIANCE          57
 
 /**
  * Default unit: pascal (Pa)
  * This is a measurement of sound pressure (acoustic pressure).
  */
-#define VSCP_TYPE_MEASUREZONE_SOUND_PRESSURE          58
+#define VSCP_TYPE_MEASUREZONE_SOUND_PRESSURE               58
 
 /**
  * Default unit: pascal (Pa)
  * Sound energy density or sound density is the sound energy per unit volume.
  */
-#define VSCP_TYPE_MEASUREZONE_SOUND_DENSITY           59
+#define VSCP_TYPE_MEASUREZONE_SOUND_DENSITY                59
 
 /**
  * Default unit: decibel (dB)
  * Sound level expressed in decibel. This event is supplied for convenience.
  */
-#define VSCP_TYPE_MEASUREZONE_SOUND_LEVEL             60
+#define VSCP_TYPE_MEASUREZONE_SOUND_LEVEL                  60
 
 /**
  * Default unit: sievert (Sv).
  * Optional unit rem (1)
  * This is a measurement of a radiation dose (Equivalent dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_EQ       61
+#define VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_EQ            61
 
 /**
  * Default unit: coulomb per kilogram (C/kg).
  * Optional unit: Röntgen/R (1)
  * This is a measurement of a radiation dose (Exposed dose of ionizing radiation).
  */
-#define VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_EXPOSURE 62
+#define VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_EXPOSURE      62
 
 /**
  * Default unit: cos of phase angle.
@@ -476,7 +477,7 @@ extern "C"
  * usually expressed as a percentage - and the lower the percentage, the less efficient power usage
  * is.
  */
-#define VSCP_TYPE_MEASUREZONE_POWER_FACTOR            63
+#define VSCP_TYPE_MEASUREZONE_POWER_FACTOR                 63
 
 /**
  * Default unit: VAr
@@ -484,14 +485,14 @@ extern "C"
  * measurement of reactive power. Reactive power exists in AC circuit when the current and voltage are
  * not in phase.
  */
-#define VSCP_TYPE_MEASUREZONE_REACTIVE_POWER          64
+#define VSCP_TYPE_MEASUREZONE_REACTIVE_POWER               64
 
 /**
  * Default unit: kVArh
  * Reactive energy is the electrical energy produced, flowing or supplied by an electric circuit
  * during a time interval, measured in units of kVArh or standard multiples thereof.
  */
-#define VSCP_TYPE_MEASUREZONE_REACTIVE_ENERGY         65
+#define VSCP_TYPE_MEASUREZONE_REACTIVE_ENERGY              65
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_type_multimedia.h
+++ b/src/vscp_type_multimedia.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_phone.h
+++ b/src/vscp_type_phone.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_protocol.h
+++ b/src/vscp_type_protocol.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_protocol.h
+++ b/src/vscp_type_protocol.h
@@ -231,6 +231,8 @@ extern "C"
  * Not mandatory. Only needed if a VSCP boot-loader algorithm is used.
  * NACK the reception of data block. This event has no meaning for any node that is not in boot mode
  * and should be disregarded.
+ * The state machine of the node that is loaded with firmware should accept new start block data
+ * events after this event. Other memory types can be programmed.
  */
 #define VSCP_TYPE_PROTOCOL_BLOCK_DATA_NACK             18
 
@@ -238,6 +240,8 @@ extern "C"
  * Not mandatory. Only needed if a VSCP boot-loader algorithm is used.
  * Request from a node to program a data block that has been uploaded and confirmed. This event has no
  * meaning for any node that is not in boot mode and should be disregarded.
+ * Sent only if the block was successfully received and confirmed by checking the crc for the full
+ * block. The block number is the number of the block that was sent in the last block data event.
  */
 #define VSCP_TYPE_PROTOCOL_PROGRAM_BLOCK_DATA          19
 
@@ -258,9 +262,14 @@ extern "C"
 /**
  * Not mandatory. Only needed if a VSCP boot-loader algorithm is used.
  * This command is sent as the last command during the boot-loader sequence. It resets the device and
- * starts it up using the newly loaded code. The 16-bit CRC for the entire program block is sent as an
- * argument. This must be correct for the reset/activation to be performed. NACK boot loader mode will
- * be sent if the CRC is not correct and the node will not leave boot loader mode.
+ * starts it up using the newly loaded code. The 16-bit sum of all CRC blocks that was transferred to
+ * the node (all memory types) is sent as an argument. This sum should be checked and be correct for
+ * the reset/activation to be performed. Activate new image NACK will be sent if the CRC is not
+ * correct and the node will not leave boot loader mode.
+ * If just one memory type is programmed, the CRC sum is the same as the CRC for the programmed block.
+ * This can be used as an alternative way to program different memory types, that is enter boot loader
+ * mode, program an area, and then activate the new image, and then enter boot loader mode again and
+ * program another area, and so on.
  */
 #define VSCP_TYPE_PROTOCOL_ACTIVATE_NEW_IMAGE          22
 
@@ -444,18 +453,42 @@ extern "C"
 /**
  * Not mandatory Only needed if a VSCP boot loader algorithm is used.
  * Part of the VSCP boot-loader functionality. This is the positive response after a node received a
- * CLASS1.PROTOCOL, Type=16 (Block data) event. It is sent by the node as a validation that it can
- * handle the block data transfer.
+ * CLASS1.PROTOCOL, Type=15 (Block data) event (a part of a block). It is sent by the node as a
+ * validation that it can handle the block data transfer.
  */
 #define VSCP_TYPE_PROTOCOL_START_BLOCK_ACK             50
 
 /**
  * Not mandatory. Only needed if a VSCP boot-loader algorithm is used.
  * Part of the VSCP boot-loader functionality. This is the negative response after a node received a
- * CLASS1.PROTOCOL, Type=16 (Block data) event. It is sent by the node as an indication that it can
- * NOT handle the block data transfer.
+ * CLASS1.PROTOCOL, Type=15 (Block data) event (a part of a block). It is sent by the node as an
+ * indication that it can NOT handle the block data transfer.
  */
 #define VSCP_TYPE_PROTOCOL_START_BLOCK_NACK            51
+
+/**
+ * Not mandatory. Only needed if a VSCP boot-loader algorithm is used.
+ * Part of the VSCP boot-loader functionality. This is the positive response after a node received
+ * CLASS1.PROTOCOL, Type=16 (Block data) event (a part of a block). It is sent by the node as a
+ * validation that it can handle the block data transfer.
+ */
+#define VSCP_TYPE_PROTOCOL_BLOCK_CHUNK_ACK             52
+
+/**
+ * Not mandatory. Only needed if a VSCP boot-loader algorithm is used.
+ * Part of the VSCP boot-loader functionality. This is the negative response after a node received
+ * CLASS1.PROTOCOL, Type=16 (Block data) event (a part of a block). It is sent by the node as an
+ * indication that it can NOT handle the block data transfer.
+ */
+#define VSCP_TYPE_PROTOCOL_BLOCK_CHUNK_NACK            53
+
+/**
+ * Not mandatory. Only needed if a VSCP boot-loader algorithm is used.
+ * Part of the VSCP boot-loader functionality. This event is a way to check if a device is already in
+ * bootloader mode. A device that is in bootloader mode should respond with a CLASS1.PROTOCOL, Type=13
+ * (ACK boot loader mode) event regardless of the internal state it is in.
+ */
+#define VSCP_TYPE_PROTOCOL_BOOT_LOADER_CHECK           54
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_type_remote.h
+++ b/src/vscp_type_remote.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_security.h
+++ b/src/vscp_type_security.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_setvaluezone.h
+++ b/src/vscp_type_setvaluezone.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_setvaluezone.h
+++ b/src/vscp_type_setvaluezone.h
@@ -149,14 +149,14 @@ extern "C"
 
 /**
  * Default unit: Joule.
- * Optional unit: KWh (1)
+ * Optional unit: kWh (1), Wh (2), eV (electron volt) (3)
  * This is a measurement of energy.
  */
 #define VSCP_TYPE_SETVALUEZONE_ENERGY                       13
 
 /**
  * Default unit: watt.
- * Optional unit: Horse power (1).
+ * Optional unit: Horse power Metric (1), Horse power Imperial (2).
  * This is a measurement of power.
  */
 #define VSCP_TYPE_SETVALUEZONE_POWER                        14
@@ -193,7 +193,7 @@ extern "C"
 
 /**
  * Default unit: amperes per meter (H).
- * Optional units: teslas (B) (1)
+ * Optional units: Oersted (Oe) (1)
  * This is a measurement of magnetic field strength.
  */
 #define VSCP_TYPE_SETVALUEZONE_MAGNETIC_FIELD_STRENGTH      20
@@ -246,8 +246,9 @@ extern "C"
 
 /**
  * Default unit: cubic meter (m³)
- * Opt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4)
- * where unit 4 is only available for Level II measurement events where units can hold this value.
+ * Opt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4),
+ * millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can
+ * hold this value.
  * This is a measurement of volume.
  */
 #define VSCP_TYPE_SETVALUEZONE_VOLUME                       28
@@ -277,13 +278,13 @@ extern "C"
 
 /**
  * Default unit: Meters per second.
- * Optional unit: Kilometers per hour (1) Miles per hour (2)
+ * Optional unit: Kilometers per hour (1), Miles per hour (2)
  * This is a measurement of a speed.
  */
 #define VSCP_TYPE_SETVALUEZONE_SPEED                        32
 
 /**
- * Default unit: Meters per second/second (m/s2).
+ * Default unit: Meter per second squared (m/s²).
  * This is a measurement of acceleration.
  */
 #define VSCP_TYPE_SETVALUEZONE_ACCELERATION                 33
@@ -339,7 +340,7 @@ extern "C"
 #define VSCP_TYPE_SETVALUEZONE_SOUND_RESISTANCE             41
 
 /**
- * Default unit: daraf (f-1).
+ * Default unit: daraf (F-1).
  * This is a measurement of electric elasticity.
  */
 #define VSCP_TYPE_SETVALUEZONE_ELECTRIC_ELASTANCE           42
@@ -401,6 +402,7 @@ extern "C"
 
 /**
  * Default unit: square meter (m²)
+ * Opt. unit: are (1), hectare (2), square kilometer (km²)
  * Area in square meter.
  */
 #define VSCP_TYPE_SETVALUEZONE_AREA                         52

--- a/src/vscp_type_setvaluezone.h
+++ b/src/vscp_type_setvaluezone.h
@@ -69,179 +69,180 @@ extern "C"
 /**
  * General Event.
  */
-#define VSCP_TYPE_SETVALUEZONE_GENERAL                 0
+#define VSCP_TYPE_SETVALUEZONE_GENERAL                      0
 
 /**
  * This is a discrete value typical for a count. There is no unit for this measurement just a discrete
  * value.
  */
-#define VSCP_TYPE_SETVALUEZONE_COUNT                   1
+#define VSCP_TYPE_SETVALUEZONE_COUNT                        1
 
 /**
  * Default unit: Meter.
  * This is a measurement of a length or a distance.
  */
-#define VSCP_TYPE_SETVALUEZONE_LENGTH                  2
+#define VSCP_TYPE_SETVALUEZONE_LENGTH                       2
 
 /**
  * Default unit: Kilogram.
  * This is a measurement of a mass.
  */
-#define VSCP_TYPE_SETVALUEZONE_MASS                    3
+#define VSCP_TYPE_SETVALUEZONE_MASS                         3
 
 /**
  * A time measurement.
  * Default unit: Seconds.
  * Opt. unit: (1) Milliseconds. Absolute: (2) y-y-m-d-h-m-s (binary). String: (3) "HHMMSS".
  */
-#define VSCP_TYPE_SETVALUEZONE_TIME                    4
+#define VSCP_TYPE_SETVALUEZONE_TIME                         4
 
 /**
  * Default unit: Ampere.
  * This is a measurement of an electric current.
  */
-#define VSCP_TYPE_SETVALUEZONE_ELECTRIC_CURRENT        5
+#define VSCP_TYPE_SETVALUEZONE_ELECTRIC_CURRENT             5
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of a temperature.
  */
-#define VSCP_TYPE_SETVALUEZONE_TEMPERATURE             6
+#define VSCP_TYPE_SETVALUEZONE_TEMPERATURE                  6
 
 /**
  * Default unit: Mole.
  * This is a measurement of an amount of a substance.
  */
-#define VSCP_TYPE_SETVALUEZONE_AMOUNT_OF_SUBSTANCE     7
+#define VSCP_TYPE_SETVALUEZONE_AMOUNT_OF_SUBSTANCE          7
 
 /**
  * Default unit: Candela.
  * This is a measurement of luminous intensity.
  */
-#define VSCP_TYPE_SETVALUEZONE_INTENSITY_OF_LIGHT      8
+#define VSCP_TYPE_SETVALUEZONE_INTENSITY_OF_LIGHT           8
 
 /**
  * Default unit: Hertz.
  * This is a measurement of regular events during a second.
  */
-#define VSCP_TYPE_SETVALUEZONE_FREQUENCY               9
+#define VSCP_TYPE_SETVALUEZONE_FREQUENCY                    9
 
 /**
  * Default unit: becquerel.
  * Optional unit: curie (1)
  * This is a measurement of rates of things, which happen randomly, or are unpredictable.
  */
-#define VSCP_TYPE_SETVALUEZONE_RADIOACTIVITY           10
+#define VSCP_TYPE_SETVALUEZONE_RADIOACTIVITY                10
 
 /**
  * Default unit: newton.
  * This is a measurement of force.
  */
-#define VSCP_TYPE_SETVALUEZONE_FORCE                   11
+#define VSCP_TYPE_SETVALUEZONE_FORCE                        11
 
 /**
  * Default unit: pascal.
  * Opt. unit: bar (1), psi (2)
  * This is a measurement of pressure.
  */
-#define VSCP_TYPE_SETVALUEZONE_PRESSURE                12
+#define VSCP_TYPE_SETVALUEZONE_PRESSURE                     12
 
 /**
  * Default unit: Joule.
  * Optional unit: KWh (1)
  * This is a measurement of energy.
  */
-#define VSCP_TYPE_SETVALUEZONE_ENERGY                  13
+#define VSCP_TYPE_SETVALUEZONE_ENERGY                       13
 
 /**
  * Default unit: watt.
  * Optional unit: Horse power (1).
  * This is a measurement of power.
  */
-#define VSCP_TYPE_SETVALUEZONE_POWER                   14
+#define VSCP_TYPE_SETVALUEZONE_POWER                        14
 
 /**
  * Default unit: coulomb.
  * This is a measurement electrical charge.
  */
-#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_CHARGE       15
+#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_CHARGE            15
 
 /**
  * Default unit: volt.
  * This is a measurement of electrical potential.
  */
-#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_POTENTIAL    16
+#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_POTENTIAL         16
 
 /**
  * Default unit: farad (F).
  * This is a measurement of electric capacitance.
  */
-#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_CAPACITANCE  17
+#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_CAPACITANCE       17
 
 /**
  * Default unit: ohm (Ω).
  * This is a measurement of resistance.
  */
-#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_RESISTANCE   18
+#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_RESISTANCE        18
 
 /**
  * Default unit: siemens.
  * This is a measurement of electrical conductance.
  */
-#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_CONDUCTANCE  19
+#define VSCP_TYPE_SETVALUEZONE_ELECTRICAL_CONDUCTANCE       19
 
 /**
  * Default unit: amperes per meter (H).
  * Optional units: teslas (B) (1)
  * This is a measurement of magnetic field strength.
  */
-#define VSCP_TYPE_SETVALUEZONE_MAGNETIC_FIELD_STRENGTH 20
+#define VSCP_TYPE_SETVALUEZONE_MAGNETIC_FIELD_STRENGTH      20
 
 /**
  * Default unit: weber (Wb).
  * This is a measurement of magnetic flux.
  */
-#define VSCP_TYPE_SETVALUEZONE_MAGNETIC_FLUX           21
+#define VSCP_TYPE_SETVALUEZONE_MAGNETIC_FLUX                21
 
 /**
  * Default unit: tesla (B).
+ * Optional units: Gauss (1)
  * This is a measurement of flux density or field strength for magnetic fields (also called the
  * magnetic induction).
  */
-#define VSCP_TYPE_SETVALUEZONE_MAGNETIC_FLUX_DENSITY   22
+#define VSCP_TYPE_SETVALUEZONE_MAGNETIC_FLUX_DENSITY        22
 
 /**
  * Default unit: henry (H).
  * This is a measurement of inductance.
  */
-#define VSCP_TYPE_SETVALUEZONE_INDUCTANCE              23
+#define VSCP_TYPE_SETVALUEZONE_INDUCTANCE                   23
 
 /**
  * Default unit: Lumen (lm= cd * sr)
  * This is a measurement of luminous Flux.
  */
-#define VSCP_TYPE_SETVALUEZONE_FLUX_OF_LIGHT           24
+#define VSCP_TYPE_SETVALUEZONE_FLUX_OF_LIGHT                24
 
 /**
  * Default unit: lux (lx) ( lx = lm / m² )
  * This is used to express both Illuminance (incidence of light) and Luminous Emittance (emission of
  * light).
  */
-#define VSCP_TYPE_SETVALUEZONE_ILLUMINANCE             25
+#define VSCP_TYPE_SETVALUEZONE_ILLUMINANCE                  25
 
 /**
  * Default unit: gray (Gy).
  * Opt unit: sievert (Sv) (1).
  * This is a measurement of a radiation dose (Absorbed dose of ionizing radiation).
  */
-#define VSCP_TYPE_SETVALUEZONE_RADIATION_DOSE          26
+#define VSCP_TYPE_SETVALUEZONE_RADIATION_DOSE               26
 
 /**
- * Default unit: katal (z).
+ * Default unit: katal (kat).
  * This is a measurement of catalytic activity used in biochemistry.
  */
-#define VSCP_TYPE_SETVALUEZONE_CATALYTIC_ACITIVITY     27
+#define VSCP_TYPE_SETVALUEZONE_CATALYTIC_ACITIVITY          27
 
 /**
  * Default unit: cubic meter (m³)
@@ -249,13 +250,13 @@ extern "C"
  * where unit 4 is only available for Level II measurement events where units can hold this value.
  * This is a measurement of volume.
  */
-#define VSCP_TYPE_SETVALUEZONE_VOLUME                  28
+#define VSCP_TYPE_SETVALUEZONE_VOLUME                       28
 
 /**
  * Default unit: W/m2, watt per square meter.
  * This is a measurement of sound intensity (acoustic intensity).
  */
-#define VSCP_TYPE_SETVALUEZONE_SOUND_INTENSITY         29
+#define VSCP_TYPE_SETVALUEZONE_SOUND_INTENSITY              29
 
 /**
  * Default unit: radian (rad) (Plane angles).
@@ -264,162 +265,163 @@ extern "C"
  * Opt Unit: arcseconds (3).
  * This is a measurement of an angle.
  */
-#define VSCP_TYPE_SETVALUEZONE_ANGLE                   30
+#define VSCP_TYPE_SETVALUEZONE_ANGLE                        30
 
 /**
  * Default unit: Longitude.
  * Opt. unit: Latitude.
- * This is a measurement of a position as of WGS 84. Normally given as a floating point value. See
- * ./class1.gps.md for a better candidate to use for position data.
+ * This is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point
+ * value. See ./class1.gps.md for a better candidate to use for position data.
  */
-#define VSCP_TYPE_SETVALUEZONE_POSITION                31
+#define VSCP_TYPE_SETVALUEZONE_POSITION                     31
 
 /**
  * Default unit: Meters per second.
  * Optional unit: Kilometers per hour (1) Miles per hour (2)
  * This is a measurement of a speed.
  */
-#define VSCP_TYPE_SETVALUEZONE_SPEED                   32
+#define VSCP_TYPE_SETVALUEZONE_SPEED                        32
 
 /**
  * Default unit: Meters per second/second (m/s2).
  * This is a measurement of acceleration.
  */
-#define VSCP_TYPE_SETVALUEZONE_ACCELERATION            33
+#define VSCP_TYPE_SETVALUEZONE_ACCELERATION                 33
 
 /**
  * Default unit: N/m.
  * This is a measurement of tension.
  */
-#define VSCP_TYPE_SETVALUEZONE_TENSION                 34
+#define VSCP_TYPE_SETVALUEZONE_TENSION                      34
 
 /**
  * Default unit: Relative percentage 0-100%.
  * This is a measurement of relative moistness (Humidity).
  */
-#define VSCP_TYPE_SETVALUEZONE_HUMIDITY                35
+#define VSCP_TYPE_SETVALUEZONE_HUMIDITY                     35
 
 /**
  * Default unit: Cubic meters/second.
  * Opt Unit: Liters/Second.
  * This is a measurement of flow.
  */
-#define VSCP_TYPE_SETVALUEZONE_FLOW                    36
+#define VSCP_TYPE_SETVALUEZONE_FLOW                         36
 
 /**
  * Default unit: Thermal ohm K/W.
  * This is a measurement of thermal resistance.
  */
-#define VSCP_TYPE_SETVALUEZONE_THERMAL_RESISTANCE      37
+#define VSCP_TYPE_SETVALUEZONE_THERMAL_RESISTANCE           37
 
 /**
  * Default unit: dioptre (dpt) m-1.
  * This is a measurement of refractive (optical) power.
  */
-#define VSCP_TYPE_SETVALUEZONE_REFRACTIVE_POWER        38
+#define VSCP_TYPE_SETVALUEZONE_REFRACTIVE_POWER             38
 
 /**
- * Default unit: poiseuille (Pl)
+ * Default unit: pascal second
+ * Optional units: poiseuille (Pl) = 1, poise (P) = 2
  * This is a measurement of dynamic viscosity.
  */
-#define VSCP_TYPE_SETVALUEZONE_DYNAMIC_VISCOSITY       39
+#define VSCP_TYPE_SETVALUEZONE_DYNAMIC_VISCOSITY            39
 
 /**
  * Default unit: rayl (Pa·s/m)
  * This is a measurement of sound impedance.
  */
-#define VSCP_TYPE_SETVALUEZONE_SOUND_IMPEDANCE         40
+#define VSCP_TYPE_SETVALUEZONE_SOUND_IMPEDANCE              40
 
 /**
  * Default unit: Acoustic ohm Pa · s/ m³.
  * This is a measurement of sound resistance.
  */
-#define VSCP_TYPE_SETVALUEZONE_SOUND_RESISTANCE        41
+#define VSCP_TYPE_SETVALUEZONE_SOUND_RESISTANCE             41
 
 /**
  * Default unit: daraf (f-1).
  * This is a measurement of electric elasticity.
  */
-#define VSCP_TYPE_SETVALUEZONE_ELECTRIC_ELASTANCE      42
+#define VSCP_TYPE_SETVALUEZONE_ELECTRIC_ELASTANCE           42
 
 /**
  * Default unit: talbot ( tb = lm * s)
  * This is a measurement of luminous energy.
  */
-#define VSCP_TYPE_SETVALUEZONE_LUMINOUS_ENERGY         43
+#define VSCP_TYPE_SETVALUEZONE_LUMINOUS_ENERGY              43
 
 /**
  * Default unit: cd / m²) (non SI unit = nit)
  * This is a measurement of luminance.
  */
-#define VSCP_TYPE_SETVALUEZONE_LUMINANCE               44
+#define VSCP_TYPE_SETVALUEZONE_LUMINANCE                    44
 
 /**
- * Default unit: molal (mol/kg).
- * This is a measurement of chemical concentration.
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mol/ppm/percent concentration.
  */
-#define VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION  45
+#define VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION_MOLAR 45
 
 /**
- * Reserved (previously was doublet of Type= 26, don't use any longer!)
+ * Default unit: mol/m³.
+ * This is a measurement of chemical mass concentration.
  */
-#define VSCP_TYPE_SETVALUEZONE_RESERVED46              46
+#define VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION_MASS  46
 
 /**
- * Default unit: sievert (J/Kg).
- * This is a measurement of dose equivalent.
+ * Reserved.
  */
-#define VSCP_TYPE_SETVALUEZONE_DOSE_EQVIVALENT         47
+#define VSCP_TYPE_SETVALUEZONE_RESERVED47                   47
 
 /**
  * Reserved (was doublet of Type= 24, do not use any longer!)
  */
-#define VSCP_TYPE_SETVALUEZONE_RESERVED48              48
+#define VSCP_TYPE_SETVALUEZONE_RESERVED48                   48
 
 /**
  * Default unit: Kelvin.
  * Opt. unit: Degree Celsius (1), Fahrenheit (2)
  * This is a measurement of the Dew Point.
  */
-#define VSCP_TYPE_SETVALUEZONE_DEWPOINT                49
+#define VSCP_TYPE_SETVALUEZONE_DEWPOINT                     49
 
 /**
  * Default unit: Relative value.
  * This is a relative value for a level measurement without a unit. It is just relative to the min/max
  * value for the selected data representation, typically percentage or per mille or similar.
  */
-#define VSCP_TYPE_SETVALUEZONE_RELATIVE_LEVEL          50
+#define VSCP_TYPE_SETVALUEZONE_RELATIVE_LEVEL               50
 
 /**
  * Default unit: Meter.
  * Opt. unit: Feet(1), inches (2)
  * Altitude in meters.
  */
-#define VSCP_TYPE_SETVALUEZONE_ALTITUDE                51
+#define VSCP_TYPE_SETVALUEZONE_ALTITUDE                     51
 
 /**
  * Default unit: square meter (m²)
  * Area in square meter.
  */
-#define VSCP_TYPE_SETVALUEZONE_AREA                    52
+#define VSCP_TYPE_SETVALUEZONE_AREA                         52
 
 /**
  * Default unit: watt per steradian ( W / sr )
  * Radiated power per room angle.
  */
-#define VSCP_TYPE_SETVALUEZONE_RADIANT_INTENSITY       53
+#define VSCP_TYPE_SETVALUEZONE_RADIANT_INTENSITY            53
 
 /**
  * Default unit: watt per steradian per square metre ( W / (sr * m²) )
  * This is the radiant flux emitted, reflected, transmitted or received by a surface.
  */
-#define VSCP_TYPE_SETVALUEZONE_RADIANCE                54
+#define VSCP_TYPE_SETVALUEZONE_RADIANCE                     54
 
 /**
  * Default unit: watt per square metre ( W / m² )
  * Power emitted from or striking onto a surface or area.
  */
-#define VSCP_TYPE_SETVALUEZONE_IRRADIANCE              55
+#define VSCP_TYPE_SETVALUEZONE_IRRADIANCE                   55
 
 /**
  * Default unit: watt per steradian per square metre per nm (W·sr-1·m-2·nm-1)
@@ -427,32 +429,32 @@ extern "C"
  * hertz (W·sr-1·m-3) (2)
  * Radiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_SETVALUEZONE_SPECTRAL_RADIANCE       56
+#define VSCP_TYPE_SETVALUEZONE_SPECTRAL_RADIANCE            56
 
 /**
  * Default unit: watt per square metre per nm (W·m-2·nm-1)
  * Opt. unit: watt per metre3 (W·m-3) (1), watt per square metre per hertz (W·m-2·Hz-1) (2)
  * Irradiance of a surface per unit frequency or wavelength.
  */
-#define VSCP_TYPE_SETVALUEZONE_SPECTRAL_IRRADIANCE     57
+#define VSCP_TYPE_SETVALUEZONE_SPECTRAL_IRRADIANCE          57
 
 /**
  * Default unit: pascal (Pa)
  * This is a measurement of sound pressure (acoustic pressure).
  */
-#define VSCP_TYPE_SETVALUEZONE_SOUND_PRESSURE          58
+#define VSCP_TYPE_SETVALUEZONE_SOUND_PRESSURE               58
 
 /**
  * Default unit: pascal (Pa)
  * Sound energy density or sound density is the sound energy per unit volume.
  */
-#define VSCP_TYPE_SETVALUEZONE_SOUND_DENSITY           59
+#define VSCP_TYPE_SETVALUEZONE_SOUND_DENSITY                59
 
 /**
  * Default unit: decibel (dB)
  * Sound level expressed in decibel. This event is supplied for convenience.
  */
-#define VSCP_TYPE_SETVALUEZONE_SOUND_LEVEL             60
+#define VSCP_TYPE_SETVALUEZONE_SOUND_LEVEL                  60
 
 /*******************************************************************************
     MACROS

--- a/src/vscp_type_weather.h
+++ b/src/vscp_type_weather.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_weather_forecast.h
+++ b/src/vscp_type_weather_forecast.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_type_wireless.h
+++ b/src/vscp_type_wireless.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_types.h
+++ b/src/vscp_types.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_util.c
+++ b/src/vscp_util.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/src/vscp_util.h
+++ b/src/vscp_util.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_action.c
+++ b/templates/vscp_action.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_action.h
+++ b/templates/vscp_action.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_app_reg.c
+++ b/templates/vscp_app_reg.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_app_reg.h
+++ b/templates/vscp_app_reg.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_config_overwrite.h
+++ b/templates/vscp_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_dev_data_config_overwrite.h
+++ b/templates/vscp_dev_data_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_platform.h
+++ b/templates/vscp_platform.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_portable.c
+++ b/templates/vscp_portable.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_portable.h
+++ b/templates/vscp_portable.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_ps_access.c
+++ b/templates/vscp_ps_access.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_ps_access.h
+++ b/templates/vscp_ps_access.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_timer.c
+++ b/templates/vscp_timer.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_timer.h
+++ b/templates/vscp_timer.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_tp_adapter.c
+++ b/templates/vscp_tp_adapter.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/templates/vscp_tp_adapter.h
+++ b/templates/vscp_tp_adapter.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/main.c
+++ b/test/main.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/makefile
+++ b/test/makefile
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 # 
-# Copyright (c) 2014 - 2024 Andreas Merkle
+# Copyright (c) 2014 - 2025 Andreas Merkle
 # http://www.blue-andi.de
 # vscp@blue-andi.de
 # 

--- a/test/makefile_cunit
+++ b/test/makefile_cunit
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 # 
-# Copyright (c) 2014 - 2024 Andreas Merkle
+# Copyright (c) 2014 - 2025 Andreas Merkle
 # http://www.blue-andi.de
 # vscp@blue-andi.de
 # 

--- a/test/vscpUser/vscp_action.c
+++ b/test/vscpUser/vscp_action.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_action.h
+++ b/test/vscpUser/vscp_action.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_app_reg.c
+++ b/test/vscpUser/vscp_app_reg.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_app_reg.h
+++ b/test/vscpUser/vscp_app_reg.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_config_overwrite.h
+++ b/test/vscpUser/vscp_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_dev_data_config_overwrite.h
+++ b/test/vscpUser/vscp_dev_data_config_overwrite.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_platform.h
+++ b/test/vscpUser/vscp_platform.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_portable.c
+++ b/test/vscpUser/vscp_portable.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_portable.h
+++ b/test/vscpUser/vscp_portable.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_ps_access.c
+++ b/test/vscpUser/vscp_ps_access.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_ps_access.h
+++ b/test/vscpUser/vscp_ps_access.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_timer.c
+++ b/test/vscpUser/vscp_timer.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_timer.h
+++ b/test/vscpUser/vscp_timer.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_tp_adapter.c
+++ b/test/vscpUser/vscp_tp_adapter.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscpUser/vscp_tp_adapter.h
+++ b/test/vscpUser/vscp_tp_adapter.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscp_stubs.h
+++ b/test/vscp_stubs.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscp_test.c
+++ b/test/vscp_test.c
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/test/vscp_test.h
+++ b/test/vscp_test.h
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *

--- a/tools/scripts/vscp-protocol2vscp-events.xsl
+++ b/tools/scripts/vscp-protocol2vscp-events.xsl
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/scripts/vscp-protocol2vscp-type-headers.xsl
+++ b/tools/scripts/vscp-protocol2vscp-type-headers.xsl
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/vscp-dm-ext-schema/vscp-dm-ext-schema.xsd
+++ b/tools/vscp-dm-ext-schema/vscp-dm-ext-schema.xsd
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/vscp-dm-std-schema/vscp-dm-std-schema.xsd
+++ b/tools/vscp-dm-std-schema/vscp-dm-std-schema.xsd
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/vscp-mdf-schema/vscp-mdf-schema.xsd
+++ b/tools/vscp-mdf-schema/vscp-mdf-schema.xsd
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/vscp-protocol-schema/vscp-protocol-schema.xsd
+++ b/tools/vscp-protocol-schema/vscp-protocol-schema.xsd
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/vscp-protocol/vscp-protocol.xml
+++ b/tools/vscp-protocol/vscp-protocol.xml
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/vscp-protocol/vscp-protocol.xml
+++ b/tools/vscp-protocol/vscp-protocol.xml
@@ -2618,13 +2618,13 @@ Notes:
                 <vscp-type id="13">
                     <name lang="en">Energy</name>
                     <token>VSCP_TYPE_MEASUREMENT_ENERGY</token>
-                    <description lang="en">Default unit: Joule.\nOptional unit: KWh (1), Wh(2)\nThis is a measurement of energy.</description>
+                    <description lang="en">Default unit: Joule.\nOptional unit: kWh (1), Wh (2), eV (electron volt) (3)\nThis is a measurement of energy.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="14">
                     <name lang="en">Power</name>
                     <token>VSCP_TYPE_MEASUREMENT_POWER</token>
-                    <description lang="en">Default unit: watt.\nOptional unit: Horse power (1).\nThis is a measurement of power.</description>
+                    <description lang="en">Default unit: watt.\nOptional unit: Horse power Metric (1), Horse power Imperial (2).\nThis is a measurement of power.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="15">
@@ -2660,7 +2660,7 @@ Notes:
                 <vscp-type id="20">
                     <name lang="en">Magnetic Field Strength</name>
                     <token>VSCP_TYPE_MEASUREMENT_MAGNETIC_FIELD_STRENGTH</token>
-                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: teslas (B) (1)\nThis is a measurement of magnetic field strength.</description>
+                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: Oersted (Oe) (1)\nThis is a measurement of magnetic field strength.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="21">
@@ -2708,7 +2708,7 @@ Notes:
                 <vscp-type id="28">
                     <name lang="en">Volume</name>
                     <token>VSCP_TYPE_MEASUREMENT_VOLUME</token>
-                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
+                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="29">
@@ -2732,13 +2732,13 @@ Notes:
                 <vscp-type id="32">
                     <name lang="en">Speed</name>
                     <token>VSCP_TYPE_MEASUREMENT_SPEED</token>
-                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1) Miles per hour (2)\nThis is a measurement of a speed.</description>
+                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1), Miles per hour (2)\nThis is a measurement of a speed.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="33">
                     <name lang="en">Acceleration</name>
                     <token>VSCP_TYPE_MEASUREMENT_ACCELERATION</token>
-                    <description lang="en">Default unit: Meters per second/second (m/s2).\nThis is a measurement of acceleration.</description>
+                    <description lang="en">Default unit: Meter per second squared (m/s²).\nThis is a measurement of acceleration.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="34">
@@ -2792,7 +2792,7 @@ Notes:
                 <vscp-type id="42">
                     <name lang="en">Electric elastance</name>
                     <token>VSCP_TYPE_MEASUREMENT_ELECTRIC_ELASTANCE</token>
-                    <description lang="en">Default unit: daraf (f-1).\nThis is a measurement of electric elasticity.</description>
+                    <description lang="en">Default unit: daraf (F-1).\nThis is a measurement of electric elasticity.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="43">
@@ -2850,7 +2850,7 @@ Notes:
                 <vscp-type id="52">
                     <name lang="en">Area</name>
                     <token>VSCP_TYPE_MEASUREMENT_AREA</token>
-                    <description lang="en">Default unit: square meter (m²)\nArea in square meter.</description>
+                    <description lang="en">Default unit: square meter (m²)\nOpt. unit: are (1), hectare (2), square kilometer (km²)\nArea in square meter.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="53">
@@ -7918,13 +7918,13 @@ Notes:
                 <vscp-type id="13">
                     <name lang="en">Energy</name>
                     <token>VSCP_TYPE_MEASUREMENT64_ENERGY</token>
-                    <description lang="en">Default unit: Joule.\nOptional unit: KWh (1)\nThis is a measurement of energy.</description>
+                    <description lang="en">Default unit: Joule.\nOptional unit: kWh (1), Wh (2), eV (electron volt) (3)\nThis is a measurement of energy.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="14">
                     <name lang="en">Power</name>
                     <token>VSCP_TYPE_MEASUREMENT64_POWER</token>
-                    <description lang="en">Default unit: watt.\nOptional unit: Horse power (1).\nThis is a measurement of power.</description>
+                    <description lang="en">Default unit: watt.\nOptional unit: Horse power Metric (1), Horse power Imperial (2).\nThis is a measurement of power.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="15">
@@ -7960,7 +7960,7 @@ Notes:
                 <vscp-type id="20">
                     <name lang="en">Magnetic Field Strength</name>
                     <token>VSCP_TYPE_MEASUREMENT64_MAGNETIC_FIELD_STRENGTH</token>
-                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: teslas (B) (1)\nThis is a measurement of magnetic field strength.</description>
+                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: Oersted (Oe) (1)\nThis is a measurement of magnetic field strength.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="21">
@@ -8008,7 +8008,7 @@ Notes:
                 <vscp-type id="28">
                     <name lang="en">Volume</name>
                     <token>VSCP_TYPE_MEASUREMENT64_VOLUME</token>
-                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
+                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="29">
@@ -8032,13 +8032,13 @@ Notes:
                 <vscp-type id="32">
                     <name lang="en">Speed</name>
                     <token>VSCP_TYPE_MEASUREMENT64_SPEED</token>
-                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1) Miles per hour (2)\nThis is a measurement of a speed.</description>
+                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1), Miles per hour (2)\nThis is a measurement of a speed.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="33">
                     <name lang="en">Acceleration</name>
                     <token>VSCP_TYPE_MEASUREMENT64_ACCELERATION</token>
-                    <description lang="en">Default unit: Meters per second/second (m/s2).\nThis is a measurement of acceleration.</description>
+                    <description lang="en">Default unit: Meter per second squared (m/s²).\nThis is a measurement of acceleration.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="34">
@@ -8092,7 +8092,7 @@ Notes:
                 <vscp-type id="42">
                     <name lang="en">Electric elastance</name>
                     <token>VSCP_TYPE_MEASUREMENT64_ELECTRIC_ELASTANCE</token>
-                    <description lang="en">Default unit: daraf (f-1).\nThis is a measurement of electric elasticity.</description>
+                    <description lang="en">Default unit: daraf (F-1).\nThis is a measurement of electric elasticity.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="43">
@@ -8150,7 +8150,7 @@ Notes:
                 <vscp-type id="52">
                     <name lang="en">Area</name>
                     <token>VSCP_TYPE_MEASUREMENT64_AREA</token>
-                    <description lang="en">Default unit: square meter (m²)\nArea in square meter.</description>
+                    <description lang="en">Default unit: square meter (m²)\nOpt. unit: are (1), hectare (2), square kilometer (km²)\nArea in square meter.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="53">
@@ -8375,13 +8375,13 @@ Notes:
                 <vscp-type id="13">
                     <name lang="en">Energy</name>
                     <token>VSCP_TYPE_MEASUREZONE_ENERGY</token>
-                    <description lang="en">Default unit: Joule.\nOptional unit: KWh (1)\nThis is a measurement of energy.</description>
+                    <description lang="en">Default unit: Joule.\nOptional unit: kWh (1), Wh (2), eV (electron volt) (3)\nThis is a measurement of energy.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="14">
                     <name lang="en">Power</name>
                     <token>VSCP_TYPE_MEASUREZONE_POWER</token>
-                    <description lang="en">Default unit: watt.\nOptional unit: Horse power (1).\nThis is a measurement of power.</description>
+                    <description lang="en">Default unit: watt.\nOptional unit: Horse power Metric (1), Horse power Imperial (2).\nThis is a measurement of power.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="15">
@@ -8417,7 +8417,7 @@ Notes:
                 <vscp-type id="20">
                     <name lang="en">Magnetic Field Strength</name>
                     <token>VSCP_TYPE_MEASUREZONE_MAGNETIC_FIELD_STRENGTH</token>
-                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: teslas (B) (1)\nThis is a measurement of magnetic field strength.</description>
+                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: Oersted (Oe) (1)\nThis is a measurement of magnetic field strength.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="21">
@@ -8465,7 +8465,7 @@ Notes:
                 <vscp-type id="28">
                     <name lang="en">Volume</name>
                     <token>VSCP_TYPE_MEASUREZONE_VOLUME</token>
-                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
+                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="29">
@@ -8489,13 +8489,13 @@ Notes:
                 <vscp-type id="32">
                     <name lang="en">Speed</name>
                     <token>VSCP_TYPE_MEASUREZONE_SPEED</token>
-                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1) Miles per hour (2)\nThis is a measurement of a speed.</description>
+                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1), Miles per hour (2)\nThis is a measurement of a speed.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="33">
                     <name lang="en">Acceleration</name>
                     <token>VSCP_TYPE_MEASUREZONE_ACCELERATION</token>
-                    <description lang="en">Default unit: Meters per second/second (m/s2).\nThis is a measurement of acceleration.</description>
+                    <description lang="en">Default unit: Meter per second squared (m/s²).\nThis is a measurement of acceleration.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="34">
@@ -8549,7 +8549,7 @@ Notes:
                 <vscp-type id="42">
                     <name lang="en">Electric elastance</name>
                     <token>VSCP_TYPE_MEASUREZONE_ELECTRIC_ELASTANCE</token>
-                    <description lang="en">Default unit: daraf (f-1).\nThis is a measurement of electric elasticity.</description>
+                    <description lang="en">Default unit: daraf (F-1).\nThis is a measurement of electric elasticity.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="43">
@@ -8607,7 +8607,7 @@ Notes:
                 <vscp-type id="52">
                     <name lang="en">Area</name>
                     <token>VSCP_TYPE_MEASUREZONE_AREA</token>
-                    <description lang="en">Default unit: square meter (m²)\nArea in square meter.</description>
+                    <description lang="en">Default unit: square meter (m²)\nOpt. unit: are (1), hectare (2), square kilometer (km²)\nArea in square meter.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="53">
@@ -8792,13 +8792,13 @@ Notes:
                 <vscp-type id="13">
                     <name lang="en">Energy</name>
                     <token>VSCP_TYPE_MEASUREMENT32_ENERGY</token>
-                    <description lang="en">Default unit: Joule.\nOptional unit: KWh (1)\nThis is a measurement of energy.</description>
+                    <description lang="en">Default unit: Joule.\nOptional unit: kWh (1), Wh (2), eV (electron volt) (3)\nThis is a measurement of energy.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="14">
                     <name lang="en">Power</name>
                     <token>VSCP_TYPE_MEASUREMENT32_POWER</token>
-                    <description lang="en">Default unit: watt.\nOptional unit: Horse power (1).\nThis is a measurement of power.</description>
+                    <description lang="en">Default unit: watt.\nOptional unit: Horse power Metric (1), Horse power Imperial (2).\nThis is a measurement of power.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="15">
@@ -8834,7 +8834,7 @@ Notes:
                 <vscp-type id="20">
                     <name lang="en">Magnetic Field Strength</name>
                     <token>VSCP_TYPE_MEASUREMENT32_MAGNETIC_FIELD_STRENGTH</token>
-                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: teslas (B) (1)\nThis is a measurement of magnetic field strength.</description>
+                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: Oersted (Oe) (1)\nThis is a measurement of magnetic field strength.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="21">
@@ -8882,7 +8882,7 @@ Notes:
                 <vscp-type id="28">
                     <name lang="en">Volume</name>
                     <token>VSCP_TYPE_MEASUREMENT32_VOLUME</token>
-                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
+                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="29">
@@ -8906,13 +8906,13 @@ Notes:
                 <vscp-type id="32">
                     <name lang="en">Speed</name>
                     <token>VSCP_TYPE_MEASUREMENT32_SPEED</token>
-                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1) Miles per hour (2)\nThis is a measurement of a speed.</description>
+                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1), Miles per hour (2)\nThis is a measurement of a speed.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="33">
                     <name lang="en">Acceleration</name>
                     <token>VSCP_TYPE_MEASUREMENT32_ACCELERATION</token>
-                    <description lang="en">Default unit: Meters per second/second (m/s2).\nThis is a measurement of acceleration.</description>
+                    <description lang="en">Default unit: Meter per second squared (m/s²).\nThis is a measurement of acceleration.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="34">
@@ -8966,7 +8966,7 @@ Notes:
                 <vscp-type id="42">
                     <name lang="en">Electric elastance</name>
                     <token>VSCP_TYPE_MEASUREMENT32_ELECTRIC_ELASTANCE</token>
-                    <description lang="en">Default unit: daraf (f-1).\nThis is a measurement of electric elasticity.</description>
+                    <description lang="en">Default unit: daraf (F-1).\nThis is a measurement of electric elasticity.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="43">
@@ -9024,7 +9024,7 @@ Notes:
                 <vscp-type id="52">
                     <name lang="en">Area</name>
                     <token>VSCP_TYPE_MEASUREMENT32_AREA</token>
-                    <description lang="en">Default unit: square meter (m²)\nArea in square meter.</description>
+                    <description lang="en">Default unit: square meter (m²)\nOpt. unit: are (1), hectare (2), square kilometer (km²)\nArea in square meter.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="53">
@@ -9198,13 +9198,13 @@ Notes:
                 <vscp-type id="13">
                     <name lang="en">Energy</name>
                     <token>VSCP_TYPE_SETVALUEZONE_ENERGY</token>
-                    <description lang="en">Default unit: Joule.\nOptional unit: KWh (1)\nThis is a measurement of energy.</description>
+                    <description lang="en">Default unit: Joule.\nOptional unit: kWh (1), Wh (2), eV (electron volt) (3)\nThis is a measurement of energy.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="14">
                     <name lang="en">Power</name>
                     <token>VSCP_TYPE_SETVALUEZONE_POWER</token>
-                    <description lang="en">Default unit: watt.\nOptional unit: Horse power (1).\nThis is a measurement of power.</description>
+                    <description lang="en">Default unit: watt.\nOptional unit: Horse power Metric (1), Horse power Imperial (2).\nThis is a measurement of power.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="15">
@@ -9240,7 +9240,7 @@ Notes:
                 <vscp-type id="20">
                     <name lang="en">Magnetic Field Strength</name>
                     <token>VSCP_TYPE_SETVALUEZONE_MAGNETIC_FIELD_STRENGTH</token>
-                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: teslas (B) (1)\nThis is a measurement of magnetic field strength.</description>
+                    <description lang="en">Default unit: amperes per meter (H).\nOptional units: Oersted (Oe) (1)\nThis is a measurement of magnetic field strength.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="21">
@@ -9288,7 +9288,7 @@ Notes:
                 <vscp-type id="28">
                     <name lang="en">Volume</name>
                     <token>VSCP_TYPE_SETVALUEZONE_VOLUME</token>
-                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), decilitre (100 cm³) (2), centilitre (10 cm³) (3), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
+                    <description lang="en">Default unit: cubic meter (m³)\nOpt. unit: Liter (dm³) (1), millilitre (cm³) (2), decilitre (100 cm³) (3), centilitre (10 cm³) (4), millilitre (cm³) (4) where unit 4 is only available for Level II measurement events where units can hold this value.\nThis is a measurement of volume.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="29">
@@ -9312,13 +9312,13 @@ Notes:
                 <vscp-type id="32">
                     <name lang="en">Speed</name>
                     <token>VSCP_TYPE_SETVALUEZONE_SPEED</token>
-                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1) Miles per hour (2)\nThis is a measurement of a speed.</description>
+                    <description lang="en">Default unit: Meters per second.\nOptional unit: Kilometers per hour (1), Miles per hour (2)\nThis is a measurement of a speed.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="33">
                     <name lang="en">Acceleration</name>
                     <token>VSCP_TYPE_SETVALUEZONE_ACCELERATION</token>
-                    <description lang="en">Default unit: Meters per second/second (m/s2).\nThis is a measurement of acceleration.</description>
+                    <description lang="en">Default unit: Meter per second squared (m/s²).\nThis is a measurement of acceleration.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="34">
@@ -9372,7 +9372,7 @@ Notes:
                 <vscp-type id="42">
                     <name lang="en">Electric elastance</name>
                     <token>VSCP_TYPE_SETVALUEZONE_ELECTRIC_ELASTANCE</token>
-                    <description lang="en">Default unit: daraf (f-1).\nThis is a measurement of electric elasticity.</description>
+                    <description lang="en">Default unit: daraf (F-1).\nThis is a measurement of electric elasticity.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="43">
@@ -9430,7 +9430,7 @@ Notes:
                 <vscp-type id="52">
                     <name lang="en">Area</name>
                     <token>VSCP_TYPE_SETVALUEZONE_AREA</token>
-                    <description lang="en">Default unit: square meter (m²)\nArea in square meter.</description>
+                    <description lang="en">Default unit: square meter (m²)\nOpt. unit: are (1), hectare (2), square kilometer (km²)\nArea in square meter.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="53">

--- a/tools/vscp-protocol/vscp-protocol.xml
+++ b/tools/vscp-protocol/vscp-protocol.xml
@@ -404,11 +404,11 @@ Notes:
                             <elements>
                                 <element pos="0" type="uint16" length="1" optional="false">
                                     <name lang="en">Block CRC</name>
-                                    <description lang="en">CRC for block.</description>
+                                    <description lang="en">The CRC is calculated over the block data only.</description>
                                 </element>
                                 <element pos="2" type="uint32" length="1" optional="false">
-                                    <name lang="en">Write pointer</name>
-                                    <description lang="en">Write pointer.</description>
+                                    <name lang="en">Block to write</name>
+                                    <description lang="en">The block to write is the block that was sent in the last block data event.</description>
                                 </element>
                             </elements>
                         </frame>
@@ -417,7 +417,7 @@ Notes:
                 <vscp-type id="18">
                     <name lang="en">NACK data block.</name>
                     <token>VSCP_TYPE_PROTOCOL_BLOCK_DATA_NACK</token>
-                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nNACK the reception of data block. This event has no meaning for any node that is not in boot mode and should be disregarded.</description>
+                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nNACK the reception of data block. This event has no meaning for any node that is not in boot mode and should be disregarded.\nThe state machine of the node that is loaded with firmware should accept new start block data events after this event. Other memory types can be programmed.</description>
                     <frames>
                         <frame id="0">
                             <name lang="en" />
@@ -428,8 +428,8 @@ Notes:
                                     <description lang="en">User defined error code.</description>
                                 </element>
                                 <element pos="1" type="uint32" length="1" optional="false">
-                                    <name lang="en">Write pointer</name>
-                                    <description lang="en">Write pointer.</description>
+                                    <name lang="en">Block to write</name>
+                                    <description lang="en">The block to write is the block that was sent in the last block data event.</description>
                                 </element>
                             </elements>
                         </frame>
@@ -438,7 +438,7 @@ Notes:
                 <vscp-type id="19">
                     <name lang="en">Program data block.</name>
                     <token>VSCP_TYPE_PROTOCOL_PROGRAM_BLOCK_DATA</token>
-                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nRequest from a node to program a data block that has been uploaded and confirmed. This event has no meaning for any node that is not in boot mode and should be disregarded.</description>
+                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nRequest from a node to program a data block that has been uploaded and confirmed. This event has no meaning for any node that is not in boot mode and should be disregarded.\nSent only if the block was successfully received and confirmed by checking the crc for the full block. The block number is the number of the block that was sent in the last block data event.</description>
                     <frames>
                         <frame id="0">
                             <name lang="en" />
@@ -493,7 +493,7 @@ Notes:
                 <vscp-type id="22">
                     <name lang="en">Activate new image.</name>
                     <token>VSCP_TYPE_PROTOCOL_ACTIVATE_NEW_IMAGE</token>
-                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nThis command is sent as the last command during the boot-loader sequence. It resets the device and starts it up using the newly loaded code. The 16-bit CRC for the entire program block is sent as an argument. This must be correct for the reset/activation to be performed. NACK boot loader mode will be sent if the CRC is not correct and the node will not leave boot loader mode.</description>
+                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nThis command is sent as the last command during the boot-loader sequence. It resets the device and starts it up using the newly loaded code. The 16-bit sum of all CRC blocks that was transferred to the node (all memory types) is sent as an argument. This sum should be checked and be correct for the reset/activation to be performed. Activate new image NACK will be sent if the CRC is not correct and the node will not leave boot loader mode.\nIf just one memory type is programmed, the CRC sum is the same as the CRC for the programmed block. This can be used as an alternative way to program different memory types, that is enter boot loader mode, program an area, and then activate the new image, and then enter boot loader mode again and program another area, and so on.</description>
                     <frames>
                         <frame id="0">
                             <name lang="en" />
@@ -501,7 +501,7 @@ Notes:
                             <elements>
                                 <element pos="0" type="uint16" length="1" optional="false">
                                     <name lang="en">CRC</name>
-                                    <description lang="en">CRC of full flash data block.</description>
+                                    <description lang="en">Sum of all CRC of blocks that was transferred to the node up to this point (all memory types).</description>
                                 </element>
                             </elements>
                         </frame>
@@ -1119,9 +1119,9 @@ Notes:
                     </frames>
                 </vscp-type>
                 <vscp-type id="50">
-                    <name lang="en">Block data transfer ACK.</name>
+                    <name lang="en">Start block ACK.</name>
                     <token>VSCP_TYPE_PROTOCOL_START_BLOCK_ACK</token>
-                    <description lang="en">Not mandatory Only needed if a VSCP boot loader algorithm is used.\nPart of the VSCP boot-loader functionality. This is the positive response after a node received a CLASS1.PROTOCOL, Type=16 (Block data) event. It is sent by the node as a validation that it can handle the block data transfer.</description>
+                    <description lang="en">Not mandatory Only needed if a VSCP boot loader algorithm is used.\nPart of the VSCP boot-loader functionality. This is the positive response after a node received a CLASS1.PROTOCOL, Type=15 (Block data) event (a part of a block). It is sent by the node as a validation that it can handle the block data transfer.</description>
                     <frames>
                         <frame id="0">
                             <name lang="en" />
@@ -1130,9 +1130,42 @@ Notes:
                     </frames>
                 </vscp-type>
                 <vscp-type id="51">
-                    <name lang="en">Block data transfer NACK.</name>
+                    <name lang="en">Start block NACK.</name>
                     <token>VSCP_TYPE_PROTOCOL_START_BLOCK_NACK</token>
-                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nPart of the VSCP boot-loader functionality. This is the negative response after a node received a CLASS1.PROTOCOL, Type=16 (Block data) event. It is sent by the node as an indication that it can NOT handle the block data transfer.</description>
+                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nPart of the VSCP boot-loader functionality. This is the negative response after a node received a CLASS1.PROTOCOL, Type=15 (Block data) event (a part of a block). It is sent by the node as an indication that it can NOT handle the block data transfer.</description>
+                    <frames>
+                        <frame id="0">
+                            <name lang="en" />
+                            <description lang="en" />
+                        </frame>
+                    </frames>
+                </vscp-type>
+                <vscp-type id="52">
+                    <name lang="en">Block Data Chunk ACK.</name>
+                    <token>VSCP_TYPE_PROTOCOL_BLOCK_CHUNK_ACK</token>
+                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nPart of the VSCP boot-loader functionality. This is the positive response after a node received CLASS1.PROTOCOL, Type=16 (Block data) event (a part of a block). It is sent by the node as a validation that it can handle the block data transfer.</description>
+                    <frames>
+                        <frame id="0">
+                            <name lang="en" />
+                            <description lang="en" />
+                        </frame>
+                    </frames>
+                </vscp-type>
+                <vscp-type id="53">
+                    <name lang="en">Block Data Chunk NACK.</name>
+                    <token>VSCP_TYPE_PROTOCOL_BLOCK_CHUNK_NACK</token>
+                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nPart of the VSCP boot-loader functionality. This is the negative response after a node received CLASS1.PROTOCOL, Type=16 (Block data) event (a part of a block). It is sent by the node as an indication that it can NOT handle the block data transfer.</description>
+                    <frames>
+                        <frame id="0">
+                            <name lang="en" />
+                            <description lang="en" />
+                        </frame>
+                    </frames>
+                </vscp-type>
+                <vscp-type id="54">
+                    <name lang="en">Bootloader CHECK.</name>
+                    <token>VSCP_TYPE_PROTOCOL_BOOT_LOADER_CHECK</token>
+                    <description lang="en">Not mandatory. Only needed if a VSCP boot-loader algorithm is used.\nPart of the VSCP boot-loader functionality. This event is a way to check if a device is already in bootloader mode. A device that is in bootloader mode should respond with a CLASS1.PROTOCOL, Type=13 (ACK boot loader mode) event regardless of the internal state it is in.</description>
                     <frames>
                         <frame id="0">
                             <name lang="en" />
@@ -2661,7 +2694,7 @@ Notes:
                 <vscp-type id="22">
                     <name lang="en">Magnetic Flux Density</name>
                     <token>VSCP_TYPE_MEASUREMENT_MAGNETIC_FLUX_DENSITY</token>
-                    <description lang="en">Default unit: tesla (B).\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
+                    <description lang="en">Default unit: tesla (B).\nOptional units: Gauss (1)\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="23">
@@ -2683,15 +2716,15 @@ Notes:
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="26">
-                    <name lang="en">Radiation dose</name>
-                    <token>VSCP_TYPE_MEASUREMENT_RADIATION_DOSE</token>
-                    <description lang="en">Default unit: gray (Gy).\nOpt unit: sievert (Sv) (1).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
+                    <name lang="en">Radiation dose (absorbed)</name>
+                    <token>VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_ABSORBED</token>
+                    <description lang="en">Default unit: gray (Gy).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="27">
                     <name lang="en">Catalytic activity</name>
                     <token>VSCP_TYPE_MEASUREMENT_CATALYTIC_ACITIVITY</token>
-                    <description lang="en">Default unit: katal (z).\nThis is a measurement of catalytic activity used in biochemistry.</description>
+                    <description lang="en">Default unit: katal (kat).\nThis is a measurement of catalytic activity used in biochemistry.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="28">
@@ -2715,7 +2748,7 @@ Notes:
                 <vscp-type id="31">
                     <name lang="en">Position WGS 84</name>
                     <token>VSCP_TYPE_MEASUREMENT_POSITION</token>
-                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
+                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="32">
@@ -2763,7 +2796,7 @@ Notes:
                 <vscp-type id="39">
                     <name lang="en">Dynamic viscosity</name>
                     <token>VSCP_TYPE_MEASUREMENT_DYNAMIC_VISCOSITY</token>
-                    <description lang="en">Default unit: poiseuille (Pl)\nThis is a measurement of dynamic viscosity.</description>
+                    <description lang="en">Default unit: pascal second\nOptional units: poiseuille (Pl) = 1, poise (P) = 2\nThis is a measurement of dynamic viscosity.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="40">
@@ -2797,20 +2830,20 @@ Notes:
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="45">
-                    <name lang="en">Chemical concentration</name>
-                    <token>VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION</token>
-                    <description lang="en">Default unit: molal (mol/kg).\nThis is a measurement of chemical concentration.</description>
+                    <name lang="en">Chemical (molar) concentration</name>
+                    <token>VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION_MOLAR</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mol/ppm/percent concentration.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="46">
-                    <name lang="en">Reserved</name>
-                    <token>VSCP_TYPE_MEASUREMENT_RESERVED46</token>
-                    <description lang="en">Reserved (previously was doublet of Type= 26, don't use any longer!)</description>
+                    <name lang="en">Chemical (mass) concentration</name>
+                    <token>VSCP_TYPE_MEASUREMENT_CHEMICAL_CONCENTRATION_MASS</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mass concentration.</description>
                 </vscp-type>
                 <vscp-type id="47">
-                    <name lang="en">Dose equivalent</name>
-                    <token>VSCP_TYPE_MEASUREMENT_DOSE_EQVIVALENT</token>
-                    <description lang="en">Default unit: sievert (J/Kg).\nThis is a measurement of dose equivalent.</description>
+                    <name lang="en">Reserved</name>
+                    <token>VSCP_TYPE_MEASUREMENT_RESERVED47</token>
+                    <description lang="en">Reserved.</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="48">
@@ -7961,7 +7994,7 @@ Notes:
                 <vscp-type id="22">
                     <name lang="en">Magnetic Flux Density</name>
                     <token>VSCP_TYPE_MEASUREMENT64_MAGNETIC_FLUX_DENSITY</token>
-                    <description lang="en">Default unit: tesla (B).\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
+                    <description lang="en">Default unit: tesla (B).\nOptional units: Gauss (1)\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="23">
@@ -7983,15 +8016,15 @@ Notes:
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="26">
-                    <name lang="en">Radiation dose</name>
-                    <token>VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE</token>
-                    <description lang="en">Default unit: gray (Gy).\nOpt unit: sievert (Sv) (1).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
+                    <name lang="en">Radiation dose (absorbed)</name>
+                    <token>VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_ABSORBED</token>
+                    <description lang="en">Default unit: gray (Gy).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="27">
                     <name lang="en">Catalytic activity</name>
                     <token>VSCP_TYPE_MEASUREMENT64_CATALYTIC_ACITIVITY</token>
-                    <description lang="en">Default unit: katal (z).\nThis is a measurement of catalytic activity used in biochemistry.</description>
+                    <description lang="en">Default unit: katal (kat).\nThis is a measurement of catalytic activity used in biochemistry.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="28">
@@ -8015,7 +8048,7 @@ Notes:
                 <vscp-type id="31">
                     <name lang="en">Position WGS 84</name>
                     <token>VSCP_TYPE_MEASUREMENT64_POSITION</token>
-                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
+                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="32">
@@ -8063,7 +8096,7 @@ Notes:
                 <vscp-type id="39">
                     <name lang="en">Dynamic viscosity</name>
                     <token>VSCP_TYPE_MEASUREMENT64_DYNAMIC_VISCOSITY</token>
-                    <description lang="en">Default unit: poiseuille (Pl)\nThis is a measurement of dynamic viscosity.</description>
+                    <description lang="en">Default unit: pascal second\nOptional units: poiseuille (Pl) = 1, poise (P) = 2\nThis is a measurement of dynamic viscosity.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="40">
@@ -8097,20 +8130,20 @@ Notes:
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="45">
-                    <name lang="en">Chemical concentration</name>
-                    <token>VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION</token>
-                    <description lang="en">Default unit: molal (mol/kg).\nThis is a measurement of chemical concentration.</description>
+                    <name lang="en">Chemical (molar) concentration</name>
+                    <token>VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION_MOLAR</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mol/ppm/percent concentration.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="46">
-                    <name lang="en">Reserved</name>
-                    <token>VSCP_TYPE_MEASUREMENT64_RESERVED46</token>
-                    <description lang="en">Reserved (previously was doublet of Type= 26, don't use any longer!)</description>
+                    <name lang="en">Chemical (mass) concentration</name>
+                    <token>VSCP_TYPE_MEASUREMENT64_CHEMICAL_CONCENTRATION_MASS</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mass concentration.</description>
                 </vscp-type>
                 <vscp-type id="47">
-                    <name lang="en">Dose equivalent</name>
-                    <token>VSCP_TYPE_MEASUREMENT64_DOSE_EQVIVALENT</token>
-                    <description lang="en">Default unit: sievert (J/Kg).\nThis is a measurement of dose equivalent.</description>
+                    <name lang="en">Reserved</name>
+                    <token>VSCP_TYPE_MEASUREMENT64_RESERVED47</token>
+                    <description lang="en">Reserved.</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="48">
@@ -8418,7 +8451,7 @@ Notes:
                 <vscp-type id="22">
                     <name lang="en">Magnetic Flux Density</name>
                     <token>VSCP_TYPE_MEASUREZONE_MAGNETIC_FLUX_DENSITY</token>
-                    <description lang="en">Default unit: tesla (B).\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
+                    <description lang="en">Default unit: tesla (B).\nOptional units: Gauss (1)\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="23">
@@ -8440,15 +8473,15 @@ Notes:
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="26">
-                    <name lang="en">Radiation dose</name>
-                    <token>VSCP_TYPE_MEASUREZONE_RADIATION_DOSE</token>
-                    <description lang="en">Default unit: gray (Gy).\nOpt unit: sievert (Sv) (1).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
+                    <name lang="en">Radiation dose (absorbed)</name>
+                    <token>VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_ABSORBED</token>
+                    <description lang="en">Default unit: gray (Gy).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="27">
                     <name lang="en">Catalytic activity</name>
                     <token>VSCP_TYPE_MEASUREZONE_CATALYTIC_ACITIVITY</token>
-                    <description lang="en">Default unit: katal (z).\nThis is a measurement of catalytic activity used in biochemistry.</description>
+                    <description lang="en">Default unit: katal (kat).\nThis is a measurement of catalytic activity used in biochemistry.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="28">
@@ -8472,7 +8505,7 @@ Notes:
                 <vscp-type id="31">
                     <name lang="en">Position WGS 84</name>
                     <token>VSCP_TYPE_MEASUREZONE_POSITION</token>
-                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
+                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="32">
@@ -8520,7 +8553,7 @@ Notes:
                 <vscp-type id="39">
                     <name lang="en">Dynamic viscosity</name>
                     <token>VSCP_TYPE_MEASUREZONE_DYNAMIC_VISCOSITY</token>
-                    <description lang="en">Default unit: poiseuille (Pl)\nThis is a measurement of dynamic viscosity.</description>
+                    <description lang="en">Default unit: pascal second\nOptional units: poiseuille (Pl) = 1, poise (P) = 2\nThis is a measurement of dynamic viscosity.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="40">
@@ -8554,20 +8587,20 @@ Notes:
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="45">
-                    <name lang="en">Chemical concentration</name>
-                    <token>VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION</token>
-                    <description lang="en">Default unit: molal (mol/kg).\nThis is a measurement of chemical concentration.</description>
+                    <name lang="en">Chemical (molar) concentration</name>
+                    <token>VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION_MOLAR</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mol/ppm/percent concentration.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="46">
-                    <name lang="en">Reserved</name>
-                    <token>VSCP_TYPE_MEASUREZONE_RESERVED46</token>
-                    <description lang="en">Reserved (previously was doublet of Type= 26, don't use any longer!)</description>
+                    <name lang="en">Chemical (mass) concentration</name>
+                    <token>VSCP_TYPE_MEASUREZONE_CHEMICAL_CONCENTRATION_MASS</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mass concentration.</description>
                 </vscp-type>
                 <vscp-type id="47">
-                    <name lang="en">Dose equivalent</name>
-                    <token>VSCP_TYPE_MEASUREZONE_DOSE_EQVIVALENT</token>
-                    <description lang="en">Default unit: sievert (J/Kg).\nThis is a measurement of dose equivalent.</description>
+                    <name lang="en">Reserved</name>
+                    <token>VSCP_TYPE_MEASUREZONE_RESERVED47</token>
+                    <description lang="en">Reserved.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="48">
@@ -8835,7 +8868,7 @@ Notes:
                 <vscp-type id="22">
                     <name lang="en">Magnetic Flux Density</name>
                     <token>VSCP_TYPE_MEASUREMENT32_MAGNETIC_FLUX_DENSITY</token>
-                    <description lang="en">Default unit: tesla (B).\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
+                    <description lang="en">Default unit: tesla (B).\nOptional units: Gauss (1)\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="23">
@@ -8857,15 +8890,15 @@ Notes:
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="26">
-                    <name lang="en">Radiation dose</name>
-                    <token>VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE</token>
-                    <description lang="en">Default unit: gray (Gy).\nOpt unit: sievert (Sv) (1).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
+                    <name lang="en">Radiation dose (absorbed)</name>
+                    <token>VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_ABSORBED</token>
+                    <description lang="en">Default unit: gray (Gy).\nThis is a measurement of a radiation dose (Absorbed dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="27">
                     <name lang="en">Catalytic activity</name>
                     <token>VSCP_TYPE_MEASUREMENT32_CATALYTIC_ACITIVITY</token>
-                    <description lang="en">Default unit: katal (z).\nThis is a measurement of catalytic activity used in biochemistry.</description>
+                    <description lang="en">Default unit: katal (kat).\nThis is a measurement of catalytic activity used in biochemistry.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="28">
@@ -8889,7 +8922,7 @@ Notes:
                 <vscp-type id="31">
                     <name lang="en">Position WGS 84</name>
                     <token>VSCP_TYPE_MEASUREMENT32_POSITION</token>
-                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
+                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="32">
@@ -8937,7 +8970,7 @@ Notes:
                 <vscp-type id="39">
                     <name lang="en">Dynamic viscosity</name>
                     <token>VSCP_TYPE_MEASUREMENT32_DYNAMIC_VISCOSITY</token>
-                    <description lang="en">Default unit: poiseuille (Pl)\nThis is a measurement of dynamic viscosity.</description>
+                    <description lang="en">Default unit: pascal second\nOptional units: poiseuille (Pl) = 1, poise (P) = 2\nThis is a measurement of dynamic viscosity.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="40">
@@ -8971,20 +9004,20 @@ Notes:
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="45">
-                    <name lang="en">Chemical concentration</name>
-                    <token>VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION</token>
-                    <description lang="en">Default unit: molal (mol/kg).\nThis is a measurement of chemical concentration.</description>
+                    <name lang="en">Chemical (molar) concentration</name>
+                    <token>VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION_MOLAR</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mol/ppm/percent concentration.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="46">
-                    <name lang="en">Reserved</name>
-                    <token>VSCP_TYPE_MEASUREMENT32_RESERVED46</token>
-                    <description lang="en">Reserved (previously was doublet of Type= 26, don't use any longer!)</description>
+                    <name lang="en">Chemical (mass) concentration</name>
+                    <token>VSCP_TYPE_MEASUREMENT32_CHEMICAL_CONCENTRATION_MASS</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mass concentration.</description>
                 </vscp-type>
                 <vscp-type id="47">
-                    <name lang="en">Dose equivalent</name>
-                    <token>VSCP_TYPE_MEASUREMENT32_DOSE_EQVIVALENT</token>
-                    <description lang="en">Default unit: sievert (J/Kg).\nThis is a measurement of dose equivalent.</description>
+                    <name lang="en">Reserved</name>
+                    <token>VSCP_TYPE_MEASUREMENT32_RESERVED47</token>
+                    <description lang="en">Reserved.</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="48">
@@ -9241,7 +9274,7 @@ Notes:
                 <vscp-type id="22">
                     <name lang="en">Magnetic Flux Density</name>
                     <token>VSCP_TYPE_SETVALUEZONE_MAGNETIC_FLUX_DENSITY</token>
-                    <description lang="en">Default unit: tesla (B).\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
+                    <description lang="en">Default unit: tesla (B).\nOptional units: Gauss (1)\nThis is a measurement of flux density or field strength for magnetic fields (also called the magnetic induction).</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="23">
@@ -9271,7 +9304,7 @@ Notes:
                 <vscp-type id="27">
                     <name lang="en">Catalytic activity</name>
                     <token>VSCP_TYPE_SETVALUEZONE_CATALYTIC_ACITIVITY</token>
-                    <description lang="en">Default unit: katal (z).\nThis is a measurement of catalytic activity used in biochemistry.</description>
+                    <description lang="en">Default unit: katal (kat).\nThis is a measurement of catalytic activity used in biochemistry.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="28">
@@ -9295,7 +9328,7 @@ Notes:
                 <vscp-type id="31">
                     <name lang="en">Position WGS 84</name>
                     <token>VSCP_TYPE_SETVALUEZONE_POSITION</token>
-                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
+                    <description lang="en">Default unit: Longitude.\nOpt. unit: Latitude.\nThis is a (decimal) measurement of a position as of WGS 84. Normally given as a floating point value. See ./class1.gps.md for a better candidate to use for position data.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="32">
@@ -9343,7 +9376,7 @@ Notes:
                 <vscp-type id="39">
                     <name lang="en">Dynamic viscosity</name>
                     <token>VSCP_TYPE_SETVALUEZONE_DYNAMIC_VISCOSITY</token>
-                    <description lang="en">Default unit: poiseuille (Pl)\nThis is a measurement of dynamic viscosity.</description>
+                    <description lang="en">Default unit: pascal second\nOptional units: poiseuille (Pl) = 1, poise (P) = 2\nThis is a measurement of dynamic viscosity.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="40">
@@ -9377,20 +9410,20 @@ Notes:
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="45">
-                    <name lang="en">Chemical concentration</name>
-                    <token>VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION</token>
-                    <description lang="en">Default unit: molal (mol/kg).\nThis is a measurement of chemical concentration.</description>
+                    <name lang="en">Chemical (molar) concentration</name>
+                    <token>VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION_MOLAR</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mol/ppm/percent concentration.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="46">
-                    <name lang="en">Reserved</name>
-                    <token>VSCP_TYPE_SETVALUEZONE_RESERVED46</token>
-                    <description lang="en">Reserved (previously was doublet of Type= 26, don't use any longer!)</description>
+                    <name lang="en">Chemical (mass) concentration</name>
+                    <token>VSCP_TYPE_SETVALUEZONE_CHEMICAL_CONCENTRATION_MASS</token>
+                    <description lang="en">Default unit: mol/m³.\nThis is a measurement of chemical mass concentration.</description>
                 </vscp-type>
                 <vscp-type id="47">
-                    <name lang="en">Dose equivalent</name>
-                    <token>VSCP_TYPE_SETVALUEZONE_DOSE_EQVIVALENT</token>
-                    <description lang="en">Default unit: sievert (J/Kg).\nThis is a measurement of dose equivalent.</description>
+                    <name lang="en">Reserved</name>
+                    <token>VSCP_TYPE_SETVALUEZONE_RESERVED47</token>
+                    <description lang="en">Reserved.</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
                 <vscp-type id="48">

--- a/tools/vscp-protocol/vscp-protocol.xml
+++ b/tools/vscp-protocol/vscp-protocol.xml
@@ -2903,7 +2903,7 @@ Notes:
                 </vscp-type>
                 <vscp-type id="61">
                     <name lang="en">Radiation dose (equivalent)</name>
-                    <token>VSCP_TYPE_MEASUREMENT_RADIATION_DOSE_EQ</token>
+                    <token>VSCP_TYPE_MEASUREMENT_DOSE_EQUIVALENT</token>
                     <description lang="en">Default unit: sievert (Sv).\nOptional unit rem (1)\nThis is a measurement of a radiation dose (Equivalent dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/10/vscp-types/1/frames</frames-ref>
                 </vscp-type>
@@ -6573,7 +6573,7 @@ Notes:
                                 </element>
                                 <element pos="3" type="uint8" length="5" optional="false">
                                     <name lang="en">Security password</name>
-                                    <description lang="en">Security password. This password can be 1-5 bytes and length of event is set accordingly. It should be interpreted as an UTF-8 string with a length set bt event data length - 3</description>
+                                    <description lang="en">Security password. This password can be 1-5 bytes and length of event is set accordingly. It should be interpreted as a UTF-8 string of length equal to the event data length minus 3 bytes</description>
                                 </element>
                             </elements>
                         </frame>
@@ -8203,7 +8203,7 @@ Notes:
                 </vscp-type>
                 <vscp-type id="61">
                     <name lang="en">Radiation dose (equivalent)</name>
-                    <token>VSCP_TYPE_MEASUREMENT64_RADIATION_DOSE_EQ</token>
+                    <token>VSCP_TYPE_MEASUREMENT64_DOSE_EQUIVALENT</token>
                     <description lang="en">Default unit: sievert (Sv).\nOptional unit rem (1)\nThis is a measurement of a radiation dose (Equivalent dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/60/vscp-types/1/frames</frames-ref>
                 </vscp-type>
@@ -8660,7 +8660,7 @@ Notes:
                 </vscp-type>
                 <vscp-type id="61">
                     <name lang="en">Radiation dose (equivalent)</name>
-                    <token>VSCP_TYPE_MEASUREZONE_RADIATION_DOSE_EQ</token>
+                    <token>VSCP_TYPE_MEASUREZONE_DOSE_EQUIVALENT</token>
                     <description lang="en">Default unit: sievert (Sv).\nOptional unit rem (1)\nThis is a measurement of a radiation dose (Equivalent dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/65/vscp-types/1/frames</frames-ref>
                 </vscp-type>
@@ -9077,7 +9077,7 @@ Notes:
                 </vscp-type>
                 <vscp-type id="61">
                     <name lang="en">Radiation dose (equivalent)</name>
-                    <token>VSCP_TYPE_MEASUREMENT32_RADIATION_DOSE_EQ</token>
+                    <token>VSCP_TYPE_MEASUREMENT32_DOSE_EQUIVALENT</token>
                     <description lang="en">Default unit: sievert (Sv).\nOptional unit rem (1)\nThis is a measurement of a radiation dose (Equivalent dose of ionizing radiation).</description>
                     <frames-ref>specification/vscp-classes/70/vscp-types/1/frames</frames-ref>
                 </vscp-type>

--- a/tools/vscp-protocol/vscp-protocol.xml
+++ b/tools/vscp-protocol/vscp-protocol.xml
@@ -1057,40 +1057,12 @@ Notes:
                                     <description lang="en">Index.</description>
                                 </element>
                                 <element pos="1" type="uint16" length="1" optional="false">
-                                    <name lang="en">Class bit 9</name>
-                                    <description lang="en">Class bit 9.</description>
-                                    <bitfield>
-                                        <bit pos="0">Bit 9 for class 1</bit>
-                                        <bit pos="1">Bit 9 for class 2</bit>
-                                        <bit pos="2">Bit 9 for class 3</bit>
-                                        <bit pos="3">All Type 1 is recognized (set type to zero). </bit>
-                                        <bit pos="4">All Type 2 is recognized (set type to zero). </bit>
-                                        <bit pos="5">All Type 3 is recognized (set type to zero). </bit>
-                                    </bitfield>
+                                    <name lang="en">Class</name>
+                                    <description lang="en">Class.</description>
                                 </element>
-                                <element pos="2" type="uint8" length="1" optional="false">
-                                    <name lang="en">Class 1</name>
-                                    <description lang="en">Class 1.</description>
-                                </element>
-                                <element pos="3" type="uint8" length="4" optional="false">
-                                    <name lang="en">Type 1</name>
-                                    <description lang="en">Type 1.</description>
-                                </element>
-                                <element pos="4" type="uint8" length="1" optional="false">
-                                    <name lang="en">Class 2</name>
-                                    <description lang="en">Class 2.</description>
-                                </element>
-                                <element pos="5" type="uint8" length="4" optional="false">
-                                    <name lang="en">Type 2</name>
-                                    <description lang="en">Type 2.</description>
-                                </element>
-                                <element pos="6" type="uint8" length="1" optional="false">
-                                    <name lang="en">Class 3</name>
-                                    <description lang="en">Class 3.</description>
-                                </element>
-                                <element pos="7" type="uint8" length="4" optional="false">
-                                    <name lang="en">Type 3</name>
-                                    <description lang="en">Type 3.</description>
+                                <element pos="3" type="uint16" length="1" optional="false">
+                                    <name lang="en">Type</name>
+                                    <description lang="en">Type.</description>
                                 </element>
                             </elements>
                         </frame>
@@ -10520,7 +10492,7 @@ Notes:
                 </vscp-type>
                 <vscp-type id="48">
                     <name lang="en">Set LED</name>
-                    <token>VSCP_TYPE_DISPLAY_SHOW_LED</token>
+                    <token>VSCP_TYPE_DISPLAY_SET_LED</token>
                     <description lang="en">This event contains information that should be displayed on LED(s) pointed out by zone/sub-zone.</description>
                     <frames>
                         <frame id="0">
@@ -10562,8 +10534,8 @@ Notes:
                 </vscp-type>
                 <vscp-type id="49">
                     <name lang="en">Set RGB Color</name>
-                    <token>VSCP_TYPE_DISPLAY_SHOW_LED_COLOR</token>
-                    <description lang="en">This event set the color for LED(s) pointed out by zone/sub-zone.</description>
+                    <token>VSCP_TYPE_DISPLAY_SET_COLOR</token>
+                    <description lang="en">This event set the color for LED(s) (or similar device) pointed out by zone/sub-zone.</description>
                     <frames>
                         <frame id="0">
                             <name lang="en" />

--- a/tools/vscp-protocol/vscp-protocol.xml
+++ b/tools/vscp-protocol/vscp-protocol.xml
@@ -1040,6 +1040,12 @@ Notes:
                         <frame id="0">
                             <name lang="en" />
                             <description lang="en" />
+                            <elements>
+                                <element pos="0" type="uint8" length="1" optional="false">
+                                    <name lang="en">Node address</name>
+                                    <description lang="en">Node address.</description>
+                                </element>
+                            </elements>
                         </frame>
                     </frames>
                 </vscp-type>

--- a/tools/xslt/utilities/ctools.xsl
+++ b/tools/xslt/utilities/ctools.xsl
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2024 Andreas Merkle
+Copyright (c) 2014 - 2025 Andreas Merkle
 http://www.blue-andi.de
 vscp@blue-andi.de
 

--- a/tools/xslt/utilities/license.txt
+++ b/tools/xslt/utilities/license.txt
@@ -1,6 +1,6 @@
 /* The MIT License (MIT)
  *
- * Copyright (c) 2014 - 2024 Andreas Merkle
+ * Copyright (c) 2014 - 2025 Andreas Merkle
  * http://www.blue-andi.de
  * vscp@blue-andi.de
  *


### PR DESCRIPTION
  * Updated to VSCP v1.15.9.
  * Supports the new VSCP_CLASS_L1_PROTOCOL events:
    * Type=52 (0x34) - Block Data Chunk ACK.
    * Type=53 (0x35) - Block Data Chunk NACK.
    * Type=54 (0x36) - Bootloader CHECK.
  * Measurement related events updated.
  * Fixed VSCP_CLASS_L1_PROTOCOL Type=40 (0x28) Missing parameter node address added.
  * A lot of unit changes in the measurement realted classes.